### PR TITLE
more accurate description of the first 16 palette colors

### DIFF
--- a/VERA Programmer's Reference.md
+++ b/VERA Programmer's Reference.md
@@ -538,7 +538,7 @@ At reset, the palette will contain a predefined palette:
 
 ![A picture of the Commander X16 palette](cx16palette.png)
 
-* Color indexes 0-15 contain the C64 color palette.
+* Color indexes 0-15 contain a palette somewhat similar to the C64 color palette.
 * Color indexes 16-31 contain a grayscale ramp.
 * Color indexes 32-255 contain various hues, saturation levels, brightness levels.
 


### PR DESCRIPTION
The first 16 colors in the current default palette aren't very well tuned to what the VIC-II actually outputs.
So I think rewording this is appropriate.

I'm no expert on this but here's a pretty thorough analysis and a better RGB representation of the C64 (VIC-II) palette https://www.pepto.de/projects/colorvic/