### PR TITLE
Fix missing Markdown line break

### DIFF
--- a/X16 Reference - 04 - KERNAL.md
+++ b/X16 Reference - 04 - KERNAL.md
@@ -408,7 +408,7 @@ ___
 
 $FEBD: `kbdbuf_peek` - get first char in keyboard queue and queue length  
 $FEC0: `kbdbuf_get_modifiers` - get currently pressed modifiers  
-$FEC3: `kbdbuf_put` - append a char to the keyboard queue
+$FEC3: `kbdbuf_put` - append a char to the keyboard queue  
 $FED2: `keymap` - set or get the current keyboard layout
 
 ___


### PR DESCRIPTION
This was bothering me. My eyeballs didn't see any other line break-related issues.