### PR TITLE
FLOAT takes signed byte, not unsigned

### DIFF
--- a/X16 Reference - 05 - Math Library.md
+++ b/X16 Reference - 05 - Math Library.md
@@ -70,7 +70,7 @@ The following calls are not part of the C128/C65 API.
 | $FE7E | DIV10    | FAC /= 10                                       |
 | $FE81 | MOVEF    | ARG = FAC                                       |
 | $FE84 | SGN      | FAC = sgn(FAC)                                  |
-| $FE87 | FLOAT    | FAC = (u8).A                                    |
+| $FE87 | FLOAT    | FAC = (s8).A                                    |
 | $FE8A | FLOATS   | FAC = (s16)facho+1:facho                        |
 | $FE8D | QINT     | facho:facho+1:facho+2:facho+2 = u32(FAC)        |
 | $FE90 | FINLOG   | FAC += (s8).A                                   |


### PR DESCRIPTION
$FE87     FLOAT     FAC = (u8).A    

This is wrong,  it loads the FAC with the _signed_ byte in A, not unsigned.
The implementation confirms this, it falls through in to FLOATS  which loads a signed word into FAC.
https://github.com/X16Community/x16-rom/blob/r42/math/code20.s#L120

(I had to change prog8 to use GIVAYF instead to get correct results from ubyte -> float conversion)
