### PR TITLE
Clarify cartridge MMIO usage

### DIFF
--- a/X16 Reference - 07 - Memory Map.md
+++ b/X16 Reference - 07 - Memory Map.md
@@ -113,7 +113,7 @@ This is the memory map of the I/O Area:
 |\$9F80-\$9F9F|Expansion Card Memory Mapped IO4     |8 MHz|
 |\$9FA0-\$9FBF|Expansion Card Memory Mapped IO5     |2 MHz|
 |\$9FC0-\$9FDF|Expansion Card Memory Mapped IO6     |2 MHz|
-|\$9FE0-\$9FFF|Expansion/Cartidge Memory Mapped IO7 |2 MHz|
+|\$9FE0-\$9FFF|Cartidge/Expansion Memory Mapped IO7 |2 MHz|
 
 #### Expansion Cards & Cartridges
 

--- a/X16 Reference - 07 - Memory Map.md
+++ b/X16 Reference - 07 - Memory Map.md
@@ -102,19 +102,18 @@ During startup, the KERNAL activates RAM bank 1 as the default for the user.
 
 This is the memory map of the I/O Area:
 
-|Addresses    |Description                         |Speed|
-|-------------|------------------------------------|-----|
-|\$9F00-\$9F0F|VIA I/O controller #1               |8 MHz|
-|\$9F10-\$9F1F|VIA I/O controller #2               |8 MHz|
-|\$9F20-\$9F3F|VERA video controller               |8 MHz|
-|\$9F40-\$9F41|YM2151 audio controller             |2 MHz|
-|\$9F42-\$9F57|Reserved                            |2 MHz|
-|\$9F58-\$9F5F|Cartridge Memory Mapped IO          |2 MHz|
-|\$9F60-\$9F7F|Expansion Card Memory Mapped IO3    |8 MHz|
-|\$9F80-\$9F9F|Expansion Card Memory Mapped IO4    |8 MHz|
-|\$9FA0-\$9FBF|Expansion Card Memory Mapped IO5    |2 MHz|
-|\$9FC0-\$9FDF|Expansion Card Memory Mapped IO6    |2 MHz|
-|\$9FE0-\$9FFF|Expansion Card Memory Mapped IO7    |2 MHz|
+|Addresses    |Description                          |Speed|
+|-------------|-------------------------------------|-----|
+|\$9F00-\$9F0F|VIA I/O controller #1                |8 MHz|
+|\$9F10-\$9F1F|VIA I/O controller #2                |8 MHz|
+|\$9F20-\$9F3F|VERA video controller                |8 MHz|
+|\$9F40-\$9F41|YM2151 audio controller              |2 MHz|
+|\$9F42-\$9F5F|Unavailable                          | --- |
+|\$9F60-\$9F7F|Expansion Card Memory Mapped IO3     |8 MHz|
+|\$9F80-\$9F9F|Expansion Card Memory Mapped IO4     |8 MHz|
+|\$9FA0-\$9FBF|Expansion Card Memory Mapped IO5     |2 MHz|
+|\$9FC0-\$9FDF|Expansion Card Memory Mapped IO6     |2 MHz|
+|\$9FE0-\$9FFF|Expansion/Cartidge Memory Mapped IO7 |2 MHz|
 
 #### Expansion Cards & Cartridges
 
@@ -125,9 +124,10 @@ though this could cause conflicts.
 
 While they may be uncomon, since cartridges are essentially external expansion cards in a 
 shell, that means they can also use MMIO. This is only necessary when a cartridge includes 
-some sort of hardware
-expansion and MMIO was desired (as opposed to using the I2C bus). 
-**It is unneeded for cartridges which simply have RAM/ROM.**
+some sort of hardware expansion and MMIO was desired (as opposed to using the I2C bus). In 
+that case, it is recommended cartridges use the IO7 range and that range should be the 
+last option used by expansion cards in the system.
+**MMIO is unneeded for cartridges which simply have RAM/ROM.**
 
 For more information, consult the 
 [Hardware](X16%20Reference%20-%2012%20-%20Hardware.md) section of the manual.

--- a/X16 Reference - 07 - Memory Map.md
+++ b/X16 Reference - 07 - Memory Map.md
@@ -120,17 +120,22 @@ This is the memory map of the I/O Area:
 
 Expansion cards can be accessed via memory-mapped I/O (MMIO), as well as I2C. Cartridges are 
 essentially expansion cards which are housed in an external enclosure and may contain RAM, ROM
-and an I2C EEPOM (for save data). Internal expansion cards may also use the RAM/ROM space, though
-this could cause conflicts.
+and an I2C EEPOM (for save data). Internal expansion cards may also use the RAM/ROM space,
+though this could cause conflicts.
 
-While they may be uncomon, since cartridges are essentially external expansion cards in a shell, that means they can also use MMIO. This is only necessary when a cartridge includes some sort of hardware
-expansion and MMIO was desired (as opposed to using the I2C bus). **It is unneeded for cartridges which simply have RAM/ROM.**
+While they may be uncomon, since cartridges are essentially external expansion cards in a 
+shell, that means they can also use MMIO. This is only necessary when a cartridge includes 
+some sort of hardware
+expansion and MMIO was desired (as opposed to using the I2C bus). 
+**It is unneeded for cartridges which simply have RAM/ROM.**
 
-For more information, consult the [Hardware](X16%20Reference%20-%2012%20-%20Hardware.md) section of the manual.
+For more information, consult the 
+[Hardware](X16%20Reference%20-%2012%20-%20Hardware.md) section of the manual.
 
 ---
 
-[^1]: Current development systems have 2 MB of bankable RAM. Actual hardware is currently planned to have an option of either 512 KB or 2 MB of RAM.
+[^1]: Current development systems have 2 MB of bankable RAM. 
+Actual hardware is currently planned to have an option of either 512 KB or 2 MB of RAM.
 
 <!-- For PDF formatting -->
 <div class="page-break"></div>

--- a/X16 Reference - 07 - Memory Map.md
+++ b/X16 Reference - 07 - Memory Map.md
@@ -102,18 +102,19 @@ During startup, the KERNAL activates RAM bank 1 as the default for the user.
 
 This is the memory map of the I/O Area:
 
-|Addresses  |Description                         |
-|-----------|------------------------------------|
-|\$9F00-\$9F0F|VIA I/O controller #1               |
-|\$9F10-\$9F1F|VIA I/O controller #2               |
-|\$9F20-\$9F3F|VERA video controller               |
-|\$9F40-\$9F41|YM2151 audio controller             |
-|\$9F42-\$9F5F|Reserved                            |
-|\$9F60-\$9F7F|Expansion Card Memory Mapped IO3    |
-|\$9F80-\$9F9F|Expansion Card Memory Mapped IO4    |
-|\$9FA0-\$9FBF|Expansion Card Memory Mapped IO5    |
-|\$9FC0-\$9FDF|Expansion Card Memory Mapped IO6    |
-|\$9FE0-\$9FFF|Expansion Card Memory Mapped IO7    |
+|Addresses    |Description                         |Speed|
+|-------------|------------------------------------|-----|
+|\$9F00-\$9F0F|VIA I/O controller #1               |8 MHz|
+|\$9F10-\$9F1F|VIA I/O controller #2               |8 MHz|
+|\$9F20-\$9F3F|VERA video controller               |8 MHz|
+|\$9F40-\$9F41|YM2151 audio controller             |2 MHz|
+|\$9F42-\$9F57|Reserved                            |2 MHz|
+|\$9F58-\$9F5F|Cartridge Memory Mapped IO          |2 MHz|
+|\$9F60-\$9F7F|Expansion Card Memory Mapped IO3    |8 MHz|
+|\$9F80-\$9F9F|Expansion Card Memory Mapped IO4    |8 MHz|
+|\$9FA0-\$9FBF|Expansion Card Memory Mapped IO5    |2 MHz|
+|\$9FC0-\$9FDF|Expansion Card Memory Mapped IO6    |2 MHz|
+|\$9FE0-\$9FFF|Expansion Card Memory Mapped IO7    |2 MHz|
 
 #### Expansion Cards & Cartridges
 
@@ -121,6 +122,9 @@ Expansion cards can be accessed via memory-mapped I/O (MMIO), as well as I2C. Ca
 essentially expansion cards which are housed in an external enclosure and may contain RAM, ROM
 and an I2C EEPOM (for save data). Internal expansion cards may also use the RAM/ROM space, though
 this could cause conflicts.
+
+While they may be uncomon, since cartridges are essentially external expansion cards in a shell, that means they can also use MMIO. This is only necessary when a cartridge includes some sort of hardware
+expansion and MMIO was desired (as opposed to using the I2C bus). **It is unneeded for cartridges which simply have RAM/ROM.**
 
 For more information, consult the [Hardware](X16%20Reference%20-%2012%20-%20Hardware.md) section of the manual.
 

--- a/X16 Reference - 12 - Hardware.md
+++ b/X16 Reference - 12 - Hardware.md
@@ -161,12 +161,14 @@ cartridges (think VRC6, Super FX, etc.) and could be used for really anything,
 such as having a MIDI input for a cartridge that is meant as a music maker; 
 some sort of hardware accelerator FPGA; network support, etc. 
 
-For more information about the memory map visit the [Memory Map](X16%20Reference%20-%2007%20-%20Memory%20Map.md) section of the manual.
+For more information about the memory map visit the 
+[Memory Map](X16%20Reference%20-%2007%20-%20Memory%20Map.md) section of the manual.
 
 ##### Booting from Cartridges
 
-After the X16 finishes it's hardware initialization, the kernel checks bank 32 for the signature "CX16"
-at `$C000`. If found, it then jumps to `$C004` and leaves interrupts disabled.
+After the X16 finishes it's hardware initialization, the kernel checks 
+bank 32 for the  signature "CX16" at `$C000`. If found, it then jumps 
+to `$C004` and leaves interrupts disabled.
 
 ### ATX Power Supply
 

--- a/X16 Reference - 12 - Hardware.md
+++ b/X16 Reference - 12 - Hardware.md
@@ -142,21 +142,26 @@ used for applications (e.g. games) with the X16 being able to boot directly from
 power on. Typically they contain a mix of banked ROM and/or RAM and an optional I2C EEPROM 
 (for storing game save states).
 
-They can also function as an expansion card which means they can also use MMIO. Similarly an internal
-expansion card could contain RAM/ROM as well.
+They can also function as an expansion card which means they can also use MMIO. 
+Similarly an internal expansion card could contain RAM/ROM as well.
 
-Because of this, while develoeprs are free to use the hardware as they please, there are open 
-discussions on suggested best practices for using cartridges and expansion cards to avoid a
-poor user experience and or compatibility issues. 
+Because of this, while develoeprs are free to use the hardware as they please, to avoid
+conflcits, the banked ROM/RAM space is expected to be used only by cartridges and
+cartridges should avoid using MMIO IO3-IO7. Instead, 8 bytes worth of MMIO (`\$9F58-\$9F5F`)
+has been reserved for cartridges in the MMIO memory map and cartridges can also use the I2C
+bus. This helps avoid bus conflicts and an  otherwise bad user experience given a 
+cartridge should be simple to use from the standpoint of the user
+("insert game -> play game").
 
-For example, there can be conflicts if an internal card uses RAM/ROM space allocated to cartridges. 
-Similarly, a cartridge can use MMIO (and doing so allows for nice features such as accelerator 
-co-processors), but care must be taken to avoid MMIO being used by internal cards. 
+These are soft guidelines. There is nothing physically preventing an expansion card from using
+banked ROM/RAM or a cartridge using any of the MMIO addresses. Doing so risks conflicts and compatibility issues.
 
-One proposal is to reserve one of the MMIO address ranges for cartridges. These conversations
-are on-going such that the final best practices as well as the final cartridge and expansion card
-designs may change. To emphasize as well, these are neighborly best practices and not 
-hard standards.
+Cartridges with additional hardware would be similar to expansion chips found on some NES and SNES 
+cartridges (think VRC6, Super FX, etc.) and could be used for really anything, 
+such as having a MIDI input for a cartridge that is meant as a music maker; 
+some sort of hardware accelerator FPGA; network support, etc. 
+
+For more information about the memory map visit the [Memory Map](X16%20Reference%20-%2007%20-%20Memory%20Map.md) section of the manual.
 
 ##### Booting from Cartridges
 

--- a/X16 Reference - 12 - Hardware.md
+++ b/X16 Reference - 12 - Hardware.md
@@ -112,24 +112,32 @@ Pin 1 is in the rear-left corner.
 |    +5V |  57 |\[ \]| 58 | GND   |
 |   +12V |  59 |\[ \]| 60 | -12V  |
 
-To simplify address decoding, pins IO3-IO7 are active for specific, 32-byte memory mapped IO (MMIO)
-address ranges.
+To simplify address decoding, pins IO3-IO7 are active for specific, 32-byte memory mapped IO 
+(MMIO) address ranges.
 
-| Address     | Description 
-|-------------|------------------
-| \$9F60-\$9FFF | Expansion port I/O range
-| \$9F60-\$9F7F | IO3
-| \$9F80-\$9F9F | IO4
-| \$9FA0-\$9FBF | IO5
-| \$9FC0-\$9FDF | IO6
-| \$9FE0-\$9FFF | IO7
+| Address     | Usage                               |Speed|
+|-------------|-------------------------------------|-----|
+|\$9F60-\$9F7F|Expansion Card Memory Mapped IO3     |8 MHz|
+|\$9F80-\$9F9F|Expansion Card Memory Mapped IO4     |8 MHz|
+|\$9FA0-\$9FBF|Expansion Card Memory Mapped IO5     |2 MHz|
+|\$9FC0-\$9FDF|Expansion Card Memory Mapped IO6     |2 MHz|
+|\$9FE0-\$9FFF|Cartidge/Expansion Memory Mapped IO7 |2 MHz|
 
-Expansion cards can use the IO3-IO7 lines as enable lines to provide their IO address range(s), or decode the address from the address bus directly. To prevent conflicts with other devices, expansion boards should allow the user to select their desired I/O bank with jumpers or DIP switches.
+Expansion cards can use the IO3-IO6 lines as enable lines to provide their IO address range
+(s), or decode the address from the address bus directly. To prevent conflicts with other 
+devices, expansion boards should allow the user to select their desired I/O bank with jumpers 
+or DIP switches. IO7 is given priority to external cartridges that use MMIO and should be 
+only used by an expansion card if there are no other MMIO ranges available. Doing so may
+cause a bus conflict with cartridges that make us of MMIO (such as those with expansion
+hardware). See below for more information on cartridges.
 
-ROMB0-ROMB7 are connected to the ROM bank latch at address `$01`. Values 0-31 (`$00`-`$1F`) address the on-board ROM chips, and 32-255 are intended for expansion ROM or RAM chips (typically used by cartridges,
-see below). This allows for a total of 3.5MB of address space in the \$C000-\$FFFF address range.
+ROMB0-ROMB7 are connected to the ROM bank latch at address `$01`. Values 0-31 (`$00`-`$1F`) 
+address the on-board ROM chips, and 32-255 are intended for expansion ROM or RAM chips 
+(typically used by cartridges, see below). This allows for a total of 3.5MB of address space 
+in the `\$C000-\$FFFF` address range.
 
-SCL and SDA pins are shared with the i2c connector on J9 and can be used to access i2c peripherals on cartridges or expansion cards.
+SCL and SDA pins are shared with the i2c connector on J9 and can be used to access i2c 
+peripherals on cartridges or expansion cards.
 
 AUDIO_L and AUDIO_R are routed to J10, the audio option header.
 
@@ -137,27 +145,30 @@ The other pins are connected to the system bus and directly to the 65C02 process
 
 #### Cartridges
 
-Cartridges are essentially an expansion card housed in an external enclosure. Typically they are 
-used for applications (e.g. games) with the X16 being able to boot directly from a cartridge at
-power on. Typically they contain a mix of banked ROM and/or RAM and an optional I2C EEPROM 
-(for storing game save states).
+Cartridges are essentially an expansion card housed in an external enclosure. Typically they
+are used for applications (e.g. games) with the X16 being able to boot directly from a 
+cartridge at power on. Typically they contain a mix of banked ROM and/or RAM and an optional 
+I2C EEPROM  (for storing game save states).
 
 They can also function as an expansion card which means they can also use MMIO. 
 Similarly an internal expansion card could contain RAM/ROM as well.
 
 Because of this, while develoeprs are free to use the hardware as they please, to avoid
-conflcits, the banked ROM/RAM space is expected to be used only by cartridges and
-cartridges should avoid using MMIO IO3-IO7. Instead, 8 bytes worth of MMIO (`\$9F58-\$9F5F`)
-has been reserved for cartridges in the MMIO memory map and cartridges can also use the I2C
-bus. This helps avoid bus conflicts and an  otherwise bad user experience given a 
+conflcits, the banked ROM/RAM space is suggested to be used only by cartridges and
+cartridges should avoid using MMIO IO3-IO6. Instead, IO7 should be the default option
+for cartridges and the last option for expansion cards (only used if there are no 
+other IO ranges available).
+
+This helps avoid bus conflicts and an otherwise bad user experience given a 
 cartridge should be simple to use from the standpoint of the user
 ("insert game -> play game").
 
 These are soft guidelines. There is nothing physically preventing an expansion card from using
-banked ROM/RAM or a cartridge using any of the MMIO addresses. Doing so risks conflicts and compatibility issues.
+banked ROM/RAM or a cartridge using any of the MMIO addresses. Doing so risks conflicts and 
+compatibility issues.
 
-Cartridges with additional hardware would be similar to expansion chips found on some NES and SNES 
-cartridges (think VRC6, Super FX, etc.) and could be used for really anything, 
+Cartridges with additional hardware would be similar to expansion chips found on some NES and 
+SNES cartridges (think VRC6, Super FX, etc.) and could be used for really anything, 
 such as having a MIDI input for a cartridge that is meant as a music maker; 
 some sort of hardware accelerator FPGA; network support, etc. 
 


### PR DESCRIPTION
Update based on below plus some Discord convos. 

TLDR:

Documentation change to suggest cartridges which require MMIO use IO7 first and expansion cards start with IO5 first (5-7 as those are the 2MHz ranges since there are only 2 8MHz ranges).