### PR TITLE
Update X16 Reference - 03 - BASIC.md - changed MON to MENU

### DIFF
--- a/X16 Reference - 03 - BASIC.md
+++ b/X16 Reference - 03 - BASIC.md
@@ -876,7 +876,7 @@ The above example parses and prints out the filenames from a directory listing.
 
 **Action:** This command currently invokes the Commander X16 Control Panel. In the future, the menu may instead present a menu of ROM-based applications and routines.
 
-**EXAMPLE of MON Statement:**
+**EXAMPLE of MENU Statement:**
 
 ```BASIC
 MENU


### PR DESCRIPTION
Saw where someone had probably copied the entry for MON to create the documentation for MENU and overlooked an instance of MON in the body of the entry.