### PR TITLE
Update X16 Reference - Appendix C - 65C02 Processor.md

### DIFF
--- a/X16 Reference - Appendix C - 65C02 Processor.md
+++ b/X16 Reference - Appendix C - 65C02 Processor.md
@@ -10,16 +10,19 @@ TODO:
 
 ## Possible 65C816 Support Compatibilty
 
-The 8-Bit Guy has indicated that a future upgrade path for the X16 may
-involve the WDC 65C816. The '816 is  _almost_ fully comnpatibe with the 
-65C02 **except** for 4 opcodes (`BBRx`, `BBSx`, `RMBx`, and `SMBx`). 
-If you plan on using these opcodes in your programs, be aware they may 
-need to be modified should the `816 become officially
-supported.
+The Commander X16 may be upgraded at some point to use the WDC 65C816.
+The 65C816 is _almost_ fully comnpatibe with the 65C02 **except** for 
+4 instructions (`BBRx`, `BBSx`, `RMBx`, and `SMBx`). 
+
+We recommend *not* using the BBR, BBS, RMB and SMB instructions, as these
+are not even fully supported across different 65C02 CPUs and the corresponding
+opcodes are completely different instructions on the 65C816. 
+
+These instruction are *not* supported on the Commander X16 as of the R47 release.
 
 ## Overview
 
-The WDC65C02 CPU is a modern version of the MOS6502 with a few additional opcodes
+The WDC65C02 CPU is a modern version of the MOS6502 with a few additional instructions
 and addressing modes capable of running at up to 14 MHz. On the Commander X16
 it is clocked at 8 MHz.
 
@@ -28,7 +31,7 @@ to serve as a convenient quick reference. Much of this information comes from
 6502.org and pagetable.com. It is been placed here for convenience though further
 information can be found at those (and other) sources.
 
-## Opcode Tables
+## Instruction Tables
 
 ### Alphabetical
 
@@ -62,7 +65,7 @@ information can be found at those (and other) sources.
 |                 |             |                 | [RMB](#rmb)[^4] [^5] |             |                 |                 |             |
 |                 |             |                 | [SMB](#smb)[^4] [^5] |             |                 |                 |             |
 
-## Opcodes
+## Instructions
 
 ### ADC
 
@@ -194,7 +197,7 @@ Branch If Carry Clear
 | --------------- | ------------- | ------ | -------- |
 | Relative        | BCC LABEL     | 3      | 2-4 [^2] |
 
-Branch to LABEL if the carry flag is clear.
+Branch to LABEL if the carry flag (C) is clear. 
 
 ### BCS
 
@@ -204,7 +207,7 @@ Branch If Carry Set
 | --------------- | ------------- | ------ | -------- |
 | Relative        | BCS LABEL     | 3      | 2-4 [^2] |
 
-Branch to LABEL if the carry flag is set.
+Branch to LABEL if the carry flag (C) is set.
 
 ### BEQ
 
@@ -214,7 +217,7 @@ Branch If Equals
 | --------------- | ------------- | ------ | -------- |
 | Relative        | BEQ LABEL     | 3      | 2-4 [^2] |
 
-Branch to LABEL if the zero flag is set.
+Branch to LABEL if the zero flag (Z) is set. 
 
 ### BIT
 
@@ -237,7 +240,7 @@ Branch If Minus
 | --------------- | ------------- | ------ | -------- |
 | Relative        | BMI LABEL     | 3      | 2-4 [^2] |
 
-Branch to LABEL if the negative flag is set.
+Branch to LABEL if the negative flag (N) is set.
 
 ### BNE
 
@@ -247,7 +250,7 @@ Branch If Not-Equal
 | --------------- | ------------- | ------ | -------- |
 | Relative        | BNE LABEL     | 3      | 2-4 [^2] |
 
-Branch to LABEL if the negative flag is set.
+Branch to LABEL if the zero (Z) flag is clear.
 
 ### BPL
 
@@ -380,9 +383,8 @@ Compare X Register
 | Zero Page       | CPX $44     | 2      | 3      |
 | Absolute        | CPX $4400   | 3      | 4      |
 
-Compare value in X with given value. Apart from the 
-fewer addressing modes, the behavior is the same
-as with [CMP](#cmp) only using the X register insteaf of
+Compare value in X with given value. The behavior is the same
+as with [CMP](#cmp) only using the X register instead of
 A.
 
 ### CPY
@@ -395,9 +397,8 @@ Compare Y Register
 | Zero Page       | CPY $44     | 2      | 3      |
 | Absolute        | CPY $4400   | 3      | 4      |
 
-Compare value in Y with given value. Apart from the 
-fewer addressing modes, the behavior is the same
-as with [CMP](#cmp) only using the Y register insteaf of
+Compare value in Y with given value. The behavior is the same
+as with [CMP](#cmp) only using the Y register instead of
 A.
 
 ### DEC
@@ -406,6 +407,7 @@ Decrement Value In Memory
 
 | Addressing Mode | Usage       | Length | Cycles |
 | --------------- | ----------- | ------ | ------ |
+| Implied / A     | DEC         | 1      | 2      |
 | Zero Page       | DEC $44     | 2      | 5      |
 | Zero Page,X     | DEC $44,X   | 2      | 6      |
 | Absolute        | DEC $4400   | 3      | 6      |
@@ -415,6 +417,9 @@ Decrement value in memory by one.
 
   - Sets N (Negative) flag if the two's compliment value is negative
   - Sets Z (Zero) flag is the value is zero
+
+Implied/A mode is specific to 65C02 and 65C816. This operates on the 
+Accumulator (A)
 
 ### DEX
 
@@ -478,6 +483,7 @@ Increment Value In Memory
 
 | Addressing Mode | Usage       | Length | Cycles |
 | --------------- | ----------- | ------ | ------ |
+| Implied / A     | INC         | 1      | 2      |
 | Zero Page       | INC $44     | 2      | 5      |
 | Zero Page,X     | INC $44,X   | 2      | 6      |
 | Absolute        | INC $4400   | 3      | 6      |
@@ -487,6 +493,9 @@ Increment value in memory by one.
 
   - Sets N (Negative) flag if the two's compliment value is negative
   - Sets Z (Zero) flag is the value is zero
+
+Implied/A mode is specific to 65C02 and 65C816. This operates on the 
+Accumulator (A)
 
 ### INX
 
@@ -1096,13 +1105,12 @@ hardware interrupt occurs. The intterupt is processed
 immediately since the processor is not otherwise running
 any instructions. This can improve interrupt timing.
 
-
 ## Status Flags
 
 Flags are stored in the P register. PHP and PLP can be used
 to directly manipulate this register. Otherwise the flags
 are used to indicate certain statuses and changed by 
-various opcodes.
+various instructions.
 
 P-Register:
 
@@ -1117,11 +1125,16 @@ P-Register:
   Z = Zero  
   C = Carry  
 
+## Opcode Matrix
+
+(TODO)
+
 ## Further Reading
 
   * <http://www.6502.org/tutorials/6502opcodes.html>
   * <http://6502.org/tutorials/65c02opcodes.html>
   * <https://www.pagetable.com/c64ref/6502/?cpu=65c02>
+  * <http://www.oxyron.de/html/opcodesc02.html>
   * <https://www.nesdev.org/wiki/Status_flags>
   * <https://skilldrick.github.io/easy6502/>
   * <https://www.westerndesigncenter.com/wdc/documentation/w65c02s.pdf>

--- a/X16 Reference - Appendix C - 65C02 Processor.md
+++ b/X16 Reference - Appendix C - 65C02 Processor.md
@@ -22,7 +22,7 @@ The 65C816 is mostly compatible with the 65C02, except for 4 instructions
 As a result, we recommend *not* using the BBR, BBS, RMB and SMB instructions, as these
 may become invalid in future versions of the Commander X16. 
 
-These instruction are *not* supported on the Commander X16 as of the R47 release.
+These instructions are *not* supported on the Commander X16 as of the R47 release.
 
 ## Overview
 


### PR DESCRIPTION
Some minor spelling issues
Added INC, DEC instructions
Replaced "opcode" with "instruction" when referring to the written form. Left "opcode" when referring to the numeric form Fixed BNE description

As noted in conversation with m00dawg and MooingLemur:
"Instruction" is the written form, ie: LDA $1234
"opcode" is preferred for the numeric form, ie: $AD

I'm pretty sure more edits will be needed. I have not confirmed all Rockwell instructions are in the list, and I'd like to add an opcode matrix, since the opcodes and brief flag listings are not included in the main body. (If writing an assembler or compiler, having this is important.)