### PR TITLE
Import 65C02 docs from merge script

### DIFF
--- a/X16 Reference - Appendix C - 65C02 Processor.md
+++ b/X16 Reference - Appendix C - 65C02 Processor.md
@@ -17,12 +17,14 @@ The Commander X16 may be upgraded at some point to use the WDC 65C816 CPU.
 The 65C816 is mostly compatible with the 65C02, except for 4 instructions
 (`BBRx`, `BBSx`, `RMBx`, and `SMBx`).
 
-These instructions are *not* supported on the Commander X16 as of the R47
-release and will generate an error when used in the emulator.
+These instructions *may* be deprecated in a future release of the emulator, and
+so we suggest not using these instructions. Some people are already using the
+65C816 in their X16 systems, and so using these instructions will cause your
+programs to malfunction on these computers.
 
 ## Instruction Tables
 
-## Opcodes By Number
+## Instructions By Number
 
 |            | x0          | x1          | x2          | x3          | x4          | x5          | x6          | x7          | x8          | x9          | xA          | xB          | xC          | xD          | xE          | xF          |
 |------------|------------|------------|------------|------------|------------|------------|------------|------------|------------|------------|------------|------------|------------|------------|------------|------------|
@@ -43,7 +45,7 @@ release and will generate an error when used in the emulator.
 |Ex           |[CPX](#cpx)|[SBC](#sbc)|||[CPX](#cpx)|[SBC](#sbc)|[INC](#inc)|[SMB6](#smbx)|[INX](#inc)|[SBC](#sbc)|[NOP](#nop)||[CPX](#cpx)|[SBC](#sbc)|[INC](#inc)|[BBS6](#bbsx)|
 |Fx           |[BEQ](#bra)|[SBC](#sbc)|[SBC](#sbc)|||[SBC](#sbc)|[INC](#inc)|[SMB7](#smbx)|[SED](#sed)|[SBC](#sbc)|[PLX](#pla)|||[SBC](#sbc)|[INC](#inc)|[BBS7](#bbsx)|
 
-## Opcodes By Name
+## Instructions By Name
 
 |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |
 |-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|
@@ -53,7 +55,7 @@ release and will generate an error when used in the emulator.
 | [ROR](#ror) | [RTI](#rti) | [RTS](#rts) | [SBC](#sbc) | [SEC](#sec) | [SED](#sed) | [SEI](#sei) | [SMBx](#smbx) | [STA](#sta) | [STP](#stp) | [STX](#stx) | [STY](#sty) | [STZ](#stz) | [TAX](#txx) | [TAY](#txx) | [TRB](#trb) |
 | [TSB](#tsb) | [TSX](#txx) | [TXA](#txx) | [TXS](#txx) | [TYA](#txx) | [WAI](#wai) |
 
-## Opcodes By Category
+## Instructions By Category
 
 |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |
 |-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|
@@ -62,11 +64,12 @@ release and will generate an error when used in the emulator.
 |  Bit Shift | [ASL](#asl) | [LSR](#lsr) | [ROL](#rol) | [ROR](#ror) |
 |  Branch | [BBRx](#bbrx) | [BBSx](#bbsx) |
 |  Test Bit | [BIT](#bit) | [TRB](#trb) | [TSB](#tsb) |
-|  Branching | [BCC](#bra) | [BCS](#bra) | [BEQ](#bra) | [BMI](#bra) | [BNE](#bra) | [BPL](#bra) | [BVC](#bra) | [BVS](#bra) | [BRA](#bra) | [JMP](#jmp) | [JSR](#jsr) | [RTI](#rti) | [RTS](#rts) |
+|  Branching | [BCC](#bra) | [BCS](#bra) | [BEQ](#bra) | [BMI](#bra) | [BNE](#bra) | [BPL](#bra) | [BVC](#bra) | [BVS](#bra) | [BRA](#bra) |
 |  Misc | [BRK](#brk) | [NOP](#nop) | [STP](#stp) | [WAI](#wai) |
 |  Flags | [CLC](#clc) | [CLD](#cld) | [CLI](#cli) | [CLV](#clv) | [SEC](#sec) | [SED](#sed) | [SEI](#sei) |
 |  Compare | [CMP](#cmp) | [CPX](#cpx) | [CPY](#cpy) |
 |  Increment/Decrement | [DEC](#dec) | [DEX](#dec) | [DEY](#dec) | [INX](#inc) | [INY](#inc) | [INC](#inc) |
+|  Flow | [JMP](#jmp) | [JSR](#jsr) | [RTI](#rti) | [RTS](#rts) |
 |  Load Data | [LDA](#lda) | [LDX](#ldx) | [LDY](#ldy) |
 |  Stack | [PHA](#pha) | [PHP](#pha) | [PHX](#pha) | [PHY](#pha) | [PLA](#pla) | [PLP](#pla) | [PLX](#pla) | [PLY](#pla) |
 |  Bit Operations | [RMBx](#rmbx) | [SMBx](#smbx) |
@@ -77,18 +80,17 @@ release and will generate an error when used in the emulator.
 
 Add with Carry
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
-ADC #$12     Immediate      $69   2     2     CZ---VN 
-ADC $12      Zero Page      $65   2     3     CZ---VN 
-ADC $12,X    Zero Page,X    $75   2     4     CZ---VN 
-ADC $1234    Absolute       $6D   3     4     CZ---VN 
-ADC $1234,X  Absolute,X     $7D   3     4     CZ---VN 
-ADC $1234,Y  Absolute,Y     $79   3     4     CZ---VN 
-ADC ($12,X)  Indirect,X     $61   2     6     CZ---VN 
-ADC ($12),Y  Indirect,Y     $71   2     5     CZ---VN 
-ADC ($12)    ZP Indirect    $72   2     5     CZ---VN +c
+ADC #$20     Immediate      $69   2     2     CZ---VN 
+ADC $20      Zero Page      $65   2     3     CZ---VN 
+ADC $20,X    Zero Page,X    $75   2     4     CZ---VN 
+ADC $8080    Absolute       $6D   3     4     CZ---VN 
+ADC $8080,X  Absolute,X     $7D   3     4     CZ---VN 
+ADC $8080,Y  Absolute,Y     $79   3     4     CZ---VN 
+ADC ($20,X)  Indirect,X     $61   2     6     CZ---VN 
+ADC ($20),Y  Indirect,Y     $71   2     5     CZ---VN 
+ADC ($20)    ZP Indirect    $72   2     5     CZ---VN +c
 ```
 
 Add a number to the Accumulator and stores the result in A.
@@ -114,18 +116,17 @@ N is set when result is negative (bit 7=1)<br/>
 
 Logical And
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
-AND #$12     Immediate      $29   2     2     -Z----N 
-AND $12      Zero Page      $25   2     3     -Z----N 
-AND $12,X    Zero Page,X    $35   2     4     -Z----N 
-AND $1234    Absolute       $2D   3     4     -Z----N 
-AND $1234,X  Absolute,X     $3D   3     4     -Z----N 
-AND $1234,Y  Absolute,Y     $39   3     4     -Z----N 
-AND ($12,X)  Indirect,X     $21   2     6     -Z----N 
-AND ($12),Y  Indirect,Y     $31   2     5     -Z----N 
-AND ($12)    ZP Indirect    $32   2     5     -Z----N +c
+AND #$20     Immediate      $29   2     2     -Z----N 
+AND $20      Zero Page      $25   2     3     -Z----N 
+AND $20,X    Zero Page,X    $35   2     4     -Z----N 
+AND $8080    Absolute       $2D   3     4     -Z----N 
+AND $8080,X  Absolute,X     $3D   3     4     -Z----N 
+AND $8080,Y  Absolute,Y     $39   3     4     -Z----N 
+AND ($20,X)  Indirect,X     $21   2     6     -Z----N 
+AND ($20),Y  Indirect,Y     $31   2     5     -Z----N 
+AND ($20)    ZP Indirect    $32   2     5     -Z----N +c
 ```
 
 Bitwise AND the provided value with the Accumulator.
@@ -161,14 +162,13 @@ in A.<br/>
 
 Arithmetic Shift Left
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
 ASL A        Accumulator    $0A   1     2     CZ----N +c
-ASL $12      Zero Page      $06   2     5     CZ----N +c
-ASL $12,X    Zero Page,X    $16   2     6     CZ----N +c
-ASL $1234    Absolute       $0E   3     6     CZ----N +c
-ASL $1234,X  Absolute,X     $1E   3    6/7    CZ----N +p
+ASL $20      Zero Page      $06   2     5     CZ----N +c
+ASL $20,X    Zero Page,X    $16   2     6     CZ----N +c
+ASL $8080    Absolute       $0E   3     6     CZ----N +c
+ASL $8080,X  Absolute,X     $1E   3    6/7    CZ----N +p
 ```
 
 Shifts all bits to the left by one position, through the Carry bit.
@@ -192,17 +192,16 @@ Bit 7 is shifted into Carry.<br/>
 
 Branch on Bit Reset
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
-BBR0 $1234   ZP Relative    $0F   3     5     ------- 
-BBR1 $1234   ZP Relative    $1F   3     5     ------- 
-BBR2 $1234   ZP Relative    $2F   3     5     ------- 
-BBR3 $1234   ZP Relative    $3F   3     5     ------- 
-BBR4 $1234   ZP Relative    $4F   3     5     ------- 
-BBR5 $1234   ZP Relative    $5F   3     5     ------- 
-BBR6 $1234   ZP Relative    $6F   3     5     ------- 
-BBR7 $1234   ZP Relative    $7F   3     5     ------- 
+BBR0 $20,$8080 ZP Relative    $0F   3     5     ------- 
+BBR1 $20,$8080 ZP Relative    $1F   3     5     ------- 
+BBR2 $20,$8080 ZP Relative    $2F   3     5     ------- 
+BBR3 $20,$8080 ZP Relative    $3F   3     5     ------- 
+BBR4 $20,$8080 ZP Relative    $4F   3     5     ------- 
+BBR5 $20,$8080 ZP Relative    $5F   3     5     ------- 
+BBR6 $20,$8080 ZP Relative    $6F   3     5     ------- 
+BBR7 $20,$8080 ZP Relative    $7F   3     5     ------- 
 ```
 
 Branch to LABEL if bit x of zero page address is 0 where x is the number of the
@@ -236,17 +235,16 @@ taken to `@flag_not_set`.
 
 Branch on Bit Set
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
-BBS0 $1234   ZP Relative    $8F   3     5     ------- 
-BBS1 $1234   ZP Relative    $9F   3     5     ------- 
-BBS2 $1234   ZP Relative    $AF   3     5     ------- 
-BBS3 $1234   ZP Relative    $BF   3     5     ------- 
-BBS4 $1234   ZP Relative    $CF   3     5     ------- 
-BBS5 $1234   ZP Relative    $DF   3     5     ------- 
-BBS6 $1234   ZP Relative    $EF   3     5     ------- 
-BBS7 $1234   ZP Relative    $FF   3     5     ------- 
+BBS0 $20,$8080 ZP Relative    $8F   3     5     ------- 
+BBS1 $20,$8080 ZP Relative    $9F   3     5     ------- 
+BBS2 $20,$8080 ZP Relative    $AF   3     5     ------- 
+BBS3 $20,$8080 ZP Relative    $BF   3     5     ------- 
+BBS4 $20,$8080 ZP Relative    $CF   3     5     ------- 
+BBS5 $20,$8080 ZP Relative    $DF   3     5     ------- 
+BBS6 $20,$8080 ZP Relative    $EF   3     5     ------- 
+BBS7 $20,$8080 ZP Relative    $FF   3     5     ------- 
 ```
 
 
@@ -281,14 +279,13 @@ taken to `@flag_set`.
 
 Test Bit
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
-BIT $12      Zero Page      $24   2     3     -Z---VN 
-BIT $1234    Absolute       $2C   3     4     -Z---VN 
-BIT #$12     Immediate      $89   2     2     -Z----- 
-BIT $12,X    Zero Page,X    $34   2     4     -Z---VN 
-BIT $1234,X  Absolute,X     $3C   3     4     -Z---VN 
+BIT $20      Zero Page      $24   2     3     -Z---VN 
+BIT $8080    Absolute       $2C   3     4     -Z---VN 
+BIT #$20     Immediate      $89   2     2     -Z----- 
+BIT $20,X    Zero Page,X    $34   2     4     -Z---VN 
+BIT $8080,X  Absolute,X     $3C   3     4     -Z---VN 
 ```
 
 - Sets Z (Zero) flag based on an AND of value provided to the Accumulator.
@@ -304,18 +301,17 @@ BIT $1234,X  Absolute,X     $3C   3     4     -Z---VN
 
 Branch Instructions
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
-BCC $1234    Relative       $90   2    2/3    ------- +p Carry Clear
-BCS $1234    Relative       $B0   2    2/3    ------- +p Carry Set
-BEQ $1234    Relative       $F0   2    2/3    ------- +p Equal: Zero bit set
-BMI $1234    Relative       $30   2    2/3    ------- +p Negative bit set
-BNE $1234    Relative       $D0   2    2/3    ------- +p Not Equal: Zero bit clear
-BPL $1234    Relative       $10   2    2/3    ------- +p Negative bit not set
-BVC $1234    Relative       $50   2    2/3    ------- +p oVerflow Clear
-BVS $1234    Relative       $70   2    2/3    ------- +p oVerflow Set
-BRA $1234    Relative       $80   2    3/4    ------- +p Always
+BCC $8080    Relative       $90   2    2/3    ------- +p Carry Clear
+BCS $8080    Relative       $B0   2    2/3    ------- +p Carry Set
+BEQ $8080    Relative       $F0   2    2/3    ------- +p Equal: Zero bit set
+BMI $8080    Relative       $30   2    2/3    ------- +p Negative bit set
+BNE $8080    Relative       $D0   2    2/3    ------- +p Not Equal: Zero bit clear
+BPL $8080    Relative       $10   2    2/3    ------- +p Negative bit not set
+BVC $8080    Relative       $50   2    2/3    ------- +p oVerflow Clear
+BVS $8080    Relative       $70   2    2/3    ------- +p oVerflow Set
+BRA $8080    Relative       $80   2    3/4    ------- +p Always
 ```
 
 The branch instructions take the branch when the related flag is Set (1) or
@@ -347,7 +343,6 @@ For example, if the PC is $1000, the statement `BCS $1023` will be `$B0 $21`.
 
 Break: Software Interrupt
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
 BRK          Implied        $00   1     7     ---DB-- 
@@ -377,7 +372,6 @@ of BASIC, rather than jumping to MONitor.
 
 Clear Carry
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
 CLC          Implied        $18   1     2     C------ 
@@ -396,7 +390,6 @@ routine or return certain information.
 
 Clear Decimal Flag
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
 CLD          Implied        $D8   1     2     ---D--- 
@@ -413,7 +406,6 @@ was previously in BCD mode.
 ### CLI
 
 Clear Interrupt Disable
-
 
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
@@ -434,7 +426,6 @@ Use SEI to disable interrupts
 
 Clear oVerflow
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
 CLV          Implied        $B8   1     2     -----V- 
@@ -451,18 +442,17 @@ Clear the Overflow (V) flag after an arithmetic operation, such as ADC or SBC.
 
 Compare A to memory
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
-CMP #$12     Immediate      $C9   2     2     CZ----N 
-CMP $12      Zero Page      $C5   2     3     CZ----N 
-CMP $12,X    Zero Page,X    $D5   2     4     CZ----N 
-CMP $1234    Absolute       $CD   3     4     CZ----N 
-CMP $1234,X  Absolute,X     $DD   3     4     CZ----N 
-CMP $1234,Y  Absolute,Y     $D9   3     4     CZ----N 
-CMP ($12,X)  Indirect,X     $C1   2     6     CZ----N 
-CMP ($12),Y  Indirect,Y     $D1   2     5     CZ----N 
-CMP ($12)    ZP Indirect    $D2   2     5     CZ----N +c
+CMP #$20     Immediate      $C9   2     2     CZ----N 
+CMP $20      Zero Page      $C5   2     3     CZ----N 
+CMP $20,X    Zero Page,X    $D5   2     4     CZ----N 
+CMP $8080    Absolute       $CD   3     4     CZ----N 
+CMP $8080,X  Absolute,X     $DD   3     4     CZ----N 
+CMP $8080,Y  Absolute,Y     $D9   3     4     CZ----N 
+CMP ($20,X)  Indirect,X     $C1   2     6     CZ----N 
+CMP ($20),Y  Indirect,Y     $D1   2     5     CZ----N 
+CMP ($20)    ZP Indirect    $D2   2     5     CZ----N +c
 ```
 
 Compares the value in the Accumulator (A) with the given value. It sets flags
@@ -483,12 +473,11 @@ based on subtracting A - _Value_.
 
 Compare X to memory
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
-CPX #$12     Immediate      $E0   2     2     CZ----N 
-CPX $12      Zero Page      $E4   2     3     CZ----N 
-CPX $1234    Absolute       $EC   3     4     CZ----N 
+CPX #$20     Immediate      $E0   2     2     CZ----N 
+CPX $20      Zero Page      $E4   2     3     CZ----N 
+CPX $8080    Absolute       $EC   3     4     CZ----N 
 ```
 
 Compares the value in the X register with the given value. It sets flags
@@ -511,12 +500,11 @@ based on subtracting X - _Value_.
 
 Compare Y to memory
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
-CPY #$12     Immediate      $C0   2     2     CZ----N 
-CPY $12      Zero Page      $C4   2     3     CZ----N 
-CPY $1234    Absolute       $CC   3     4     CZ----N 
+CPY #$20     Immediate      $C0   2     2     CZ----N 
+CPY $20      Zero Page      $C4   2     3     CZ----N 
+CPY $8080    Absolute       $CC   3     4     CZ----N 
 ```
 
 Compares the value in the Y register with the given value. It sets flags
@@ -537,13 +525,12 @@ based on subtracting Y - _Value_.
 
 Decrement Value
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
-DEC $12      Zero Page      $C6   2     5     -Z----N 
-DEC $12,X    Zero Page,X    $D6   2     6     -Z----N 
-DEC $1234    Absolute       $CE   3     6     -Z----N 
-DEC $1234,X  Absolute,X     $DE   3     7     -Z----N 
+DEC $20      Zero Page      $C6   2     5     -Z----N 
+DEC $20,X    Zero Page,X    $D6   2     6     -Z----N 
+DEC $8080    Absolute       $CE   3     6     -Z----N 
+DEC $8080,X  Absolute,X     $DE   3     7     -Z----N 
 DEC A        Accumulator    $3A   1     2     -Z----N 
 DEX          Implied        $CA   1     2     -Z----N 
 DEY          Implied        $88   1     2     -Z----N 
@@ -583,18 +570,17 @@ LABEL DEC Num_Low
 
 Exclusive OR
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
-EOR #$12     Immediate      $49   2     2     -Z----N 
-EOR $12      Zero Page      $45   2     3     -Z----N 
-EOR $12,X    Zero Page,X    $55   2     4     -Z----N 
-EOR $1234    Absolute       $4D   3     4     -Z----N 
-EOR $1234,X  Absolute,X     $5D   3     4     -Z----N 
-EOR $1234,Y  Absolute,Y     $59   3     4     -Z----N 
-EOR ($12,X)  Indirect,X     $41   2     6     -Z----N 
-EOR ($12),Y  Indirect,Y     $51   2     5     -Z----N 
-EOR ($12)    ZP Indirect    $52   2     5     -Z----N +c
+EOR #$20     Immediate      $49   2     2     -Z----N 
+EOR $20      Zero Page      $45   2     3     -Z----N 
+EOR $20,X    Zero Page,X    $55   2     4     -Z----N 
+EOR $8080    Absolute       $4D   3     4     -Z----N 
+EOR $8080,X  Absolute,X     $5D   3     4     -Z----N 
+EOR $8080,Y  Absolute,Y     $59   3     4     -Z----N 
+EOR ($20,X)  Indirect,X     $41   2     6     -Z----N 
+EOR ($20),Y  Indirect,Y     $51   2     5     -Z----N 
+EOR ($20)    ZP Indirect    $52   2     5     -Z----N +c
 ```
 
 
@@ -634,15 +620,14 @@ tested. It returns a 0 for each bit that is the same.
 
 Increment Value
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
 INX          Implied        $E8   1     2     -Z----N 
 INY          Implied        $C8   1     2     -Z----N 
-INC $12      Zero Page      $E6   2     5     -Z----N 
-INC $12,X    Zero Page,X    $F6   2     6     -Z----N 
-INC $1234    Absolute       $EE   3     6     -Z----N 
-INC $1234,X  Absolute,X     $FE   3     7     -Z----N 
+INC $20      Zero Page      $E6   2     5     -Z----N 
+INC $20,X    Zero Page,X    $F6   2     6     -Z----N 
+INC $8080    Absolute       $EE   3     6     -Z----N 
+INC $8080,X  Absolute,X     $FE   3     7     -Z----N 
 INC A        Accumulator    $1A   1     2     -Z----N 
 ```
 
@@ -679,12 +664,11 @@ Inc16_1: ...
 
 Jump to new address
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
-JMP $1234    Absolute       $4C   3     3     ------- 
-JMP ($1234)  Indirect       $6C   3     5     ------- 
-JMP $1234,X  Absolute,X     $7C   3     6     ------- 
+JMP $8080    Absolute       $4C   3     3     ------- 
+JMP ($8080)  Indirect       $6C   3     5     ------- 
+JMP $8080,X  Absolute,X     $7C   3     6     ------- 
 ```
 
 Jump to specified memory location and begin execution
@@ -724,10 +708,9 @@ RTS.
 
 Jump to Subroutine
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
-JSR $1234    Absolute       $20   3     6     ------- 
+JSR $8080    Absolute       $20   3     6     ------- 
 ```
 
 Stores the address of the Program Counter to the stack.<br/>
@@ -749,18 +732,17 @@ either overflow or underflow the stack.
 
 Read memory to Accumulator
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
-LDA #$12     Immediate      $A9   2     2     -Z----N 
-LDA $12      Zero Page      $A5   2     3     -Z----N 
-LDA $12,X    Zero Page,X    $B5   2     4     -Z----N 
-LDA $1234    Absolute       $AD   3     4     -Z----N 
-LDA $1234,X  Absolute,X     $BD   3     4     -Z----N +p
-LDA $1234,Y  Absolute,Y     $B9   3     4     -Z----N +p
-LDA ($12,X)  Indirect,X     $A1   2     6     -Z----N 
-LDA ($12),Y  Indirect,Y     $B1   2     5     -Z----N +p
-LDA ($12)    ZP Indirect    $B2   2     5     -Z----N +c
+LDA #$20     Immediate      $A9   2     2     -Z----N 
+LDA $20      Zero Page      $A5   2     3     -Z----N 
+LDA $20,X    Zero Page,X    $B5   2     4     -Z----N 
+LDA $8080    Absolute       $AD   3     4     -Z----N 
+LDA $8080,X  Absolute,X     $BD   3     4     -Z----N +p
+LDA $8080,Y  Absolute,Y     $B9   3     4     -Z----N +p
+LDA ($20,X)  Indirect,X     $A1   2     6     -Z----N 
+LDA ($20),Y  Indirect,Y     $B1   2     5     -Z----N +p
+LDA ($20)    ZP Indirect    $B2   2     5     -Z----N +c
 ```
 
 Place the given value from memory into the accumulator (A).
@@ -780,14 +762,13 @@ Place the given value from memory into the accumulator (A).
 
 Read memory to X Index Register
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
-LDX #$12     Immediate      $A2   2     2     -Z----N 
-LDX $12      Zero Page      $A6   2     3     -Z----N 
-LDX $12,Y    Zero Page,Y    $B6   2     4     -Z----N 
-LDX $1234    Absolute       $AE   3     4     -Z----N 
-LDX $1234,Y  Absolute,Y     $BE   3     4     -Z----N +p
+LDX #$20     Immediate      $A2   2     2     -Z----N 
+LDX $20      Zero Page      $A6   2     3     -Z----N 
+LDX $20,Y    Zero Page,Y    $B6   2     4     -Z----N 
+LDX $8080    Absolute       $AE   3     4     -Z----N 
+LDX $8080,Y  Absolute,Y     $BE   3     4     -Z----N +p
 ```
 
 Place the given value from memory into the X register.
@@ -807,14 +788,13 @@ Place the given value from memory into the X register.
 
 Read memory to Y Index Register
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
-LDY #$12     Immediate      $A0   2     2     -Z----N 
-LDY $12      Zero Page      $A4   2     3     -Z----N 
-LDY $12,X    Zero Page,X    $B4   2     4     -Z----N 
-LDY $1234    Absolute       $AC   3     4     -Z----N 
-LDY $1234,X  Absolute,X     $BC   3     4     -Z----N +p
+LDY #$20     Immediate      $A0   2     2     -Z----N 
+LDY $20      Zero Page      $A4   2     3     -Z----N 
+LDY $20,X    Zero Page,X    $B4   2     4     -Z----N 
+LDY $8080    Absolute       $AC   3     4     -Z----N 
+LDY $8080,X  Absolute,X     $BC   3     4     -Z----N +p
 ```
 
 Place the given value from memory into the Y register.
@@ -834,14 +814,13 @@ Place the given value from memory into the Y register.
 
 Logical Shift Right
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
 LSR A        Accumulator    $4A   1     2     -Z----N 
-LSR $12      Zero Page      $46   2     5     -Z----N 
-LSR $12,X    Zero Page,X    $56   2     6     -Z----N 
-LSR $1234    Absolute       $4E   3     6     -Z----N 
-LSR $1234,X  Absolute,X     $5E   3    6/7    -Z----N [^2]
+LSR $20      Zero Page      $46   2     5     -Z----N 
+LSR $20,X    Zero Page,X    $56   2     6     -Z----N 
+LSR $8080    Absolute       $4E   3     6     -Z----N 
+LSR $8080,X  Absolute,X     $5E   3    6/7    -Z----N [^2]
 ```
 
 Shifts all bits to the right by one position, through the Carry bit.
@@ -864,7 +843,6 @@ The Carry bit is shifted into bit 7.<br/>
 ### NOP
 
 No Operation
-
 
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
@@ -891,18 +869,17 @@ bit of delay when writing to the YM2151 chip (see
 
 Logical OR
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
-ORA #$12     Immediate      $09   2     2     -Z----N 
-ORA $12      Zero Page      $05   2     3     -Z----N 
-ORA $12,X    Zero Page,X    $15   2     4     -Z----N 
-ORA $1234    Absolute       $0D   3     4     -Z----N 
-ORA $1234,X  Absolute,X     $1D   3     4     -Z----N 
-ORA $1234,Y  Absolute,Y     $19   3     4     -Z----N 
-ORA ($12,X)  Indirect,X     $01   2     6     -Z----N 
-ORA ($12),Y  Indirect,Y     $11   2     5     -Z----N 
-ORA ($12)    ZP Indirect    $12   2     5     -Z----N +c
+ORA #$20     Immediate      $09   2     2     -Z----N 
+ORA $20      Zero Page      $05   2     3     -Z----N 
+ORA $20,X    Zero Page,X    $15   2     4     -Z----N 
+ORA $8080    Absolute       $0D   3     4     -Z----N 
+ORA $8080,X  Absolute,X     $1D   3     4     -Z----N 
+ORA $8080,Y  Absolute,Y     $19   3     4     -Z----N 
+ORA ($20,X)  Indirect,X     $01   2     6     -Z----N 
+ORA ($20),Y  Indirect,Y     $11   2     5     -Z----N 
+ORA ($20)    ZP Indirect    $12   2     5     -Z----N +c
 ```
 
 Perform a logical OR of the given value in A
@@ -936,7 +913,6 @@ Perform a logical OR of the given value in A
 
 Push to stack
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
 PHA          Implied        $48   1     3     ------- 
@@ -966,7 +942,6 @@ and [PHY](#pla).
 ### PLA
 
 Pull from stack
-
 
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
@@ -1000,17 +975,16 @@ and [PHY](#pha).
 
 Memory Bit Operations
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
-RMB0 $12     Zero Page      $07   2     5     ------- +c -816
-RMB1 $12     Zero Page      $17   2     5     ------- +c -816
-RMB2 $12     Zero Page      $27   2     5     ------- +c -816
-RMB3 $12     Zero Page      $37   2     5     ------- +c -816
-RMB4 $12     Zero Page      $47   2     5     ------- +c -816
-RMB5 $12     Zero Page      $57   2     5     ------- +c -816
-RMB6 $12     Zero Page      $67   2     5     ------- +c -816
-RMB7 $12     Zero Page      $77   2     5     ------- +c -816
+RMB0 $20     Zero Page      $07   2     5     ------- +c -816
+RMB1 $20     Zero Page      $17   2     5     ------- +c -816
+RMB2 $20     Zero Page      $27   2     5     ------- +c -816
+RMB3 $20     Zero Page      $37   2     5     ------- +c -816
+RMB4 $20     Zero Page      $47   2     5     ------- +c -816
+RMB5 $20     Zero Page      $57   2     5     ------- +c -816
+RMB6 $20     Zero Page      $67   2     5     ------- +c -816
+RMB7 $20     Zero Page      $77   2     5     ------- +c -816
 ```
 
 Set bit x to 0 at the given zero page address where x is the number of the
@@ -1030,14 +1004,13 @@ Often used in conjunction with [BBR](#bbrx) and [BBS](#bbsx).
 
 Rotate Left
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
 ROL A        Accumulator    $2A   1     2     CZ----N 
-ROL $12      Zero Page      $26   2     5     CZ----N 
-ROL $12,X    Zero Page,X    $36   2     6     CZ----N 
-ROL $1234    Absolute       $2E   3     6     CZ----N 
-ROL $1234,X  Absolute,X     $3E   3    6/7    CZ----N +p
+ROL $20      Zero Page      $26   2     5     CZ----N 
+ROL $20,X    Zero Page,X    $36   2     6     CZ----N 
+ROL $8080    Absolute       $2E   3     6     CZ----N 
+ROL $8080,X  Absolute,X     $3E   3    6/7    CZ----N +p
 ```
 
 Rotate all bits to the left one position. The value in the carry (C) flag is
@@ -1057,14 +1030,13 @@ shifted into bit 0 and the original bit 7 is shifted into the carry (C).
 
 Rotate Right
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
 ROR A        Accumulator    $6A   1     2     CZ----N 
-ROR $12      Zero Page      $66   2     5     CZ----N 
-ROR $12,X    Zero Page,X    $76   2     6     CZ----N 
-ROR $1234    Absolute       $7E   3     6     CZ----N 
-ROR $1234,X  Absolute,X     $6E   3    6/7    CZ----N [^2]
+ROR $20      Zero Page      $66   2     5     CZ----N 
+ROR $20,X    Zero Page,X    $76   2     6     CZ----N 
+ROR $8080    Absolute       $7E   3     6     CZ----N 
+ROR $8080,X  Absolute,X     $6E   3    6/7    CZ----N [^2]
 ```
 
 Rotate all bits to the right one position. The value in
@@ -1082,7 +1054,6 @@ bit 0 is shifted into the carry (C).
 ### RTI
 
 Return from Interrupt
-
 
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
@@ -1105,7 +1076,6 @@ return address (rather than address-1).
 
 Return from Subroutine
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
 RTS          Implied        $60   1     6     ------- 
@@ -1125,18 +1095,17 @@ control to that address +1.
 
 Subtract With Carry
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
-SBC #$12     Immediate      $E9   2     2     CZ---VN 
-SBC $12      Zero Page      $E5   2     3     CZ---VN 
-SBC $12,X    Zero Page,X    $F5   2     4     CZ---VN 
-SBC $1234    Absolute       $ED   3     4     CZ---VN 
-SBC $1234,X  Absolute,X     $FD   3     4     CZ---VN 
-SBC $1234,Y  Absolute,Y     $F9   3     4     CZ---VN 
-SBC ($12,X)  Indirect,X     $E1   2     6     CZ---VN 
-SBC ($12),Y  Indirect,Y     $F1   2     5     CZ---VN 
-SBC ($12)    ZP Indirect    $F2   2     5     CZ---VN +c
+SBC #$20     Immediate      $E9   2     2     CZ---VN 
+SBC $20      Zero Page      $E5   2     3     CZ---VN 
+SBC $20,X    Zero Page,X    $F5   2     4     CZ---VN 
+SBC $8080    Absolute       $ED   3     4     CZ---VN 
+SBC $8080,X  Absolute,X     $FD   3     4     CZ---VN 
+SBC $8080,Y  Absolute,Y     $F9   3     4     CZ---VN 
+SBC ($20,X)  Indirect,X     $E1   2     6     CZ---VN 
+SBC ($20),Y  Indirect,Y     $F1   2     5     CZ---VN 
+SBC ($20)    ZP Indirect    $F2   2     5     CZ---VN +c
 ```
 
 Subtract the operand from A and places the result in A.
@@ -1164,7 +1133,6 @@ N is set when result is negative (bit 7=1)<br/>
 
 Set Carry
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
 SEC          Implied        $38   1     2     C------ 
@@ -1182,7 +1150,6 @@ or return certain information.
 ### SED
 
 Set Decimal
-
 
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
@@ -1208,7 +1175,6 @@ rounding.
 
 Set Interrupt Disable
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
 SEI          Implied        $78   1     2     --I---- 
@@ -1227,17 +1193,16 @@ interrupts.
 
 Set Memory Bit
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
-SMB0 $12     Zero Page      $87   2     5     ------- +c -816
-SMB1 $12     Zero Page      $97   2     5     ------- +c -816
-SMB2 $12     Zero Page      $A7   2     5     ------- +c -816
-SMB3 $12     Zero Page      $B7   2     5     ------- +c -816
-SMB4 $12     Zero Page      $C7   2     5     ------- +c -816
-SMB5 $12     Zero Page      $D7   2     5     ------- +c -816
-SMB6 $12     Zero Page      $E7   2     5     ------- +c -816
-SMB7 $12     Zero Page      $F7   2     5     ------- +c -816
+SMB0 $20     Zero Page      $87   2     5     ------- +c -816
+SMB1 $20     Zero Page      $97   2     5     ------- +c -816
+SMB2 $20     Zero Page      $A7   2     5     ------- +c -816
+SMB3 $20     Zero Page      $B7   2     5     ------- +c -816
+SMB4 $20     Zero Page      $C7   2     5     ------- +c -816
+SMB5 $20     Zero Page      $D7   2     5     ------- +c -816
+SMB6 $20     Zero Page      $E7   2     5     ------- +c -816
+SMB7 $20     Zero Page      $F7   2     5     ------- +c -816
 ```
 
 Set bit x to 1 at the given zero page address where x is the number
@@ -1259,17 +1224,16 @@ Specific to the 65C02 (*unavailable on the 65C816*)
 
 Store Accumulator contents to memory
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
-STA $12      Zero Page      $85   2     3     ------- 
-STA $12,X    Zero Page,X    $95   2     4     ------- 
-STA $1234    Absolute       $8D   3     4     ------- 
-STA $1234,X  Absolute,X     $9D   3     5     ------- 
-STA $1234,Y  Absolute,Y     $99   3     5     ------- 
-STA ($12,X)  Indirect,X     $81   2     6     ------- 
-STA ($12),Y  Indirect,Y     $91   2     6     ------- 
-STA ($12)    ZP Indirect    $92   2     5     ------- +c
+STA $20      Zero Page      $85   2     3     ------- 
+STA $20,X    Zero Page,X    $95   2     4     ------- 
+STA $8080    Absolute       $8D   3     4     ------- 
+STA $8080,X  Absolute,X     $9D   3     5     ------- 
+STA $8080,Y  Absolute,Y     $99   3     5     ------- 
+STA ($20,X)  Indirect,X     $81   2     6     ------- 
+STA ($20),Y  Indirect,Y     $91   2     6     ------- 
+STA ($20)    ZP Indirect    $92   2     5     ------- +c
 ```
 
 Place the given value from the accumulator (A) into memory.
@@ -1284,7 +1248,6 @@ Place the given value from the accumulator (A) into memory.
 ### STP
 
 Stop
-
 
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
@@ -1310,12 +1273,11 @@ emulator or reset the emulation.
 
 Save X Index Register contents to memory
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
-STX $12      Zero Page      $86   2     3     ------- 
-STX $12,Y    Zero Page,Y    $96   2     4     ------- 
-STX $1234    Absolute       $8E   3     4     ------- 
+STX $20      Zero Page      $86   2     3     ------- 
+STX $20,Y    Zero Page,Y    $96   2     4     ------- 
+STX $8080    Absolute       $8E   3     4     ------- 
 ```
 
 
@@ -1328,12 +1290,11 @@ STX $1234    Absolute       $8E   3     4     -------
 
 Save Y Index Register contents to memory
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
-STY $12      Zero Page      $84   2     3     ------- 
-STY $12,X    Zero Page,X    $94   2     4     ------- 
-STY $1234    Absolute       $8C   3     4     ------- 
+STY $20      Zero Page      $84   2     3     ------- 
+STY $20,X    Zero Page,X    $94   2     4     ------- 
+STY $8080    Absolute       $8C   3     4     ------- 
 ```
 
 
@@ -1346,13 +1307,12 @@ STY $1234    Absolute       $8C   3     4     -------
 
 Set memory to zero
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
-STZ $12      Zero Page      $64   2     3     ------- 
-STZ $12,X    Zero Page,X    $74   2     4     ------- 
-STZ $1234    Absolute       $9C   3     4     ------- 
-STZ $1234,X  Absolute,X     $9E   3     5     ------- 
+STZ $20      Zero Page      $64   2     3     ------- 
+STZ $20,X    Zero Page,X    $74   2     4     ------- 
+STZ $8080    Absolute       $9C   3     4     ------- 
+STZ $8080,X  Absolute,X     $9E   3     5     ------- 
 ```
 
 
@@ -1365,11 +1325,10 @@ STZ $1234,X  Absolute,X     $9E   3     5     -------
 
 Test and reset bit
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
-TRB $12      Zero Page      $14   2     5     -Z----- 
-TRB $1234    Absolute       $1C   3     5     -Z----- 
+TRB $20      Zero Page      $14   2     5     -Z----- 
+TRB $8080    Absolute       $1C   3     5     -Z----- 
 ```
 
 Effectively an inverted AND between memory and the Accumulator. The bits that
@@ -1404,11 +1363,10 @@ STA $20  ; Store it back to memory.
 
 Test and set bit
 
-
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
-TSB $12      Zero Page      $04   2     5     -Z----- 
-TSB $1234    Absolute       $0C   3     5     -Z----- 
+TSB $20      Zero Page      $04   2     5     -Z----- 
+TSB $8080    Absolute       $0C   3     5     -Z----- 
 ```
 
 Performs an OR with each bit in the accumulator and memory.
@@ -1426,7 +1384,6 @@ data is 0.
 ### Txx
 
 Transfer between registers
-
 
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
@@ -1457,7 +1414,6 @@ TXS
 ### WAI
 
 Wait
-
 
 ```text
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    

--- a/X16 Reference - Appendix C - 65C02 Processor.md
+++ b/X16 Reference - Appendix C - 65C02 Processor.md
@@ -1,155 +1,224 @@
-
 # Appendix C: The 65C02 Processor
 
-This is not meant to be a complete manual on the 65C02 processor, though is meant 
-to serve as a convenient quick reference. Much of this information comes from
-6502.org and pagetable.com. It is been placed here for convenience though further
-information can be found at those (and other) sources.
-
-## Work In Progress
-
-TODO:
-
-  * Add 65C02 addressing modes for ADC AND CMP EOR LDA ORA SBC STA
-  * Add flag changes where relevant (likely missing some)
-
-## Possible 65C816 Support Compatibilty
-
-The Commander X16 may be upgraded at some point to use the WDC 65C816 CPU.
-The 65C816 is mostly compatible with the 65C02, except for 4 instructions 
-(`BBRx`, `BBSx`, `RMBx`, and `SMBx`).
-
-As a result, we recommend *not* using the BBR, BBS, RMB and SMB instructions, as these
-may become invalid in future versions of the Commander X16. 
-
-These instructions are *not* supported on the Commander X16 as of the R47 release.
+This is not meant to be a complete manual on the 65C02 processor, though is
+meant to serve as a convenient quick reference. Much of this information comes
+from 6502.org and pagetable.com. It is been placed here for convenience though
+further information can be found at those (and other) sources.
 
 ## Overview
 
-The WDC65C02 CPU is a modern version of the MOS6502 with a few additional instructions
-and addressing modes and is capable of running at up to 14 MHz. On the Commander X16
-it is clocked at 8 MHz.
+The WDC65C02 CPU is a modern version of the MOS6502 with a few additional
+instructions and addressing modes and is capable of running at up to 14 MHz. On
+the Commander X16, it is clocked at 8 MHz.
+
+## A note about 65C816 Compatibilty
+
+The Commander X16 may be upgraded at some point to use the WDC 65C816 CPU.
+The 65C816 is mostly compatible with the 65C02, except for 4 instructions
+(`BBRx`, `BBSx`, `RMBx`, and `SMBx`).
+
+These instructions are *not* supported on the Commander X16 as of the R47
+release and will generate an error when used in the emulator.
 
 ## Instruction Tables
 
-### Alphabetical
+## Opcodes By Number
 
-|     |     |     |     |     |     |     |     |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| [ADC](#adc)     | [AND](#and)     | [ASL](#asl) | [BBR](#bbr)[^4] [^5] | [BBS](#bbs)[^4] [^5] | [BCC](#bcc)     | [BCS](#bcs)     | [BEQ](#beq)     |
-| [BIT](#bit)     | [BMI](#bmi)     | [BNE](#bne) | [BPL](#bpl)     | [BRA](#bra)     | [BRK](#brk)     | [BVC](#bvc)     | [BVS](#bvs)     |
-| [CLC](#clc)     | [CLD](#cld)     | [CLI](#cli) | [CLV](#clv)     | [CMP](#cmp)     | [CPX](#cpx)     | [CPY](#cpy)     | [DEC](#dec)     |
-| [DEX](#dex)     | [DEY](#dey)     | [EOR](#eor) | [INC](#inc)     | [INX](#inx)     | [INY](#iny)     | [JMP](#jmp)     | [JSR](#jsr)     |
-| [LDA](#lda)     | [LDX](#ldx)     | [LDY](#ldy) | [LSR](#lsr)     | [NOP](#nop)     | [ORA](#ora)     | [PHA](#pha)     | [PHP](#php)     |
-| [PHX](#phx)[^4] | [PHY](#phy)[^4] | [PLA](#pla) | [PLP](#plp)     | [PLX](#plx)[^4] | [PLY](#ply)[^4] | [RMB](#rmb)[^4] [^5] | [ROL](#rol)     |
-| [ROR](#ror)     | [RTI](#rti)     | [RTS](#rts) | [SBC](#sbc)     | [SEC](#sec)     | [SED](#sed)     | [SEI](#sei)     | [SMB](#smb)[^4] [^5] | 
-| [STA](#sta)     | [STP](#stp)[^4] | [STX](#stx) | [STY](#sty)     | [STZ](#stz)[^4] | [TAX](#tax)     | [TAY](#tay)     | [TRB](#trb)[^4] | 
-| [TSB](#trb)[^4] | [TSX](#tsx)     | [TXA](#txa) | [TXS](#txs)     | [TYA](#tya)     | [WAI](#wai)[^4] |                 |                 |
+|            | x0          | x1          | x2          | x3          | x4          | x5          | x6          | x7          | x8          | x9          | xA          | xB          | xC          | xD          | xE          | xF          |
+|------------|------------|------------|------------|------------|------------|------------|------------|------------|------------|------------|------------|------------|------------|------------|------------|------------|
+|0x           |[BRK](#brk)|[ORA](#ora)|||[TSB](#tsb)|[ORA](#ora)|[ASL](#asl)|[RMB0](#rmbx)|[PHP](#pha)|[ORA](#ora)|[ASL](#asl)||[TSB](#tsb)|[ORA](#ora)|[ASL](#asl)|[BBR0](#bbrx)|
+|1x           |[BPL](#bra)|[ORA](#ora)|[ORA](#ora)||[TRB](#trb)|[ORA](#ora)|[ASL](#asl)|[RMB1](#rmbx)|[CLC](#clc)|[ORA](#ora)|[INC](#inc)||[TRB](#trb)|[ORA](#ora)|[ASL](#asl)|[BBR1](#bbrx)|
+|2x           |[JSR](#jsr)|[AND](#and)|||[BIT](#bit)|[AND](#and)|[ROL](#rol)|[RMB2](#rmbx)|[PLP](#pla)|[AND](#and)|[ROL](#rol)||[BIT](#bit)|[AND](#and)|[ROL](#rol)|[BBR2](#bbrx)|
+|3x           |[BMI](#bra)|[AND](#and)|[AND](#and)||[BIT](#bit)|[AND](#and)|[ROL](#rol)|[RMB3](#rmbx)|[SEC](#sec)|[AND](#and)|[DEC](#dec)||[BIT](#bit)|[AND](#and)|[ROL](#rol)|[BBR3](#bbrx)|
+|4x           |[RTI](#rti)|[EOR](#eor)||||[EOR](#eor)|[LSR](#lsr)|[RMB4](#rmbx)|[PHA](#pha)|[EOR](#eor)|[LSR](#lsr)||[JMP](#jmp)|[EOR](#eor)|[LSR](#lsr)|[BBR4](#bbrx)|
+|5x           |[BVC](#bra)|[EOR](#eor)|[EOR](#eor)|||[EOR](#eor)|[LSR](#lsr)|[RMB5](#rmbx)|[CLI](#cli)|[EOR](#eor)|[PHY](#pha)|||[EOR](#eor)|[LSR](#lsr)|[BBR5](#bbrx)|
+|6x           |[RTS](#rts)|[ADC](#adc)|||[STZ](#stz)|[ADC](#adc)|[ROR](#ror)|[RMB6](#rmbx)|[PLA](#pla)|[ADC](#adc)|[ROR](#ror)||[JMP](#jmp)|[ADC](#adc)|[ROR](#ror)|[BBR6](#bbrx)|
+|7x           |[BVS](#bra)|[ADC](#adc)|[ADC](#adc)||[STZ](#stz)|[ADC](#adc)|[ROR](#ror)|[RMB7](#rmbx)|[SEI](#sei)|[ADC](#adc)|[PLY](#pla)||[JMP](#jmp)|[ADC](#adc)|[ROR](#ror)|[BBR7](#bbrx)|
+|8x           |[BRA](#bra)|[STA](#sta)|||[STY](#sty)|[STA](#sta)|[STX](#stx)|[SMB0](#smbx)|[DEY](#dec)|[BIT](#bit)|[TXA](#txx)||[STY](#sty)|[STA](#sta)|[STX](#stx)|[BBS0](#bbsx)|
+|9x           |[BCC](#bra)|[STA](#sta)|[STA](#sta)||[STY](#sty)|[STA](#sta)|[STX](#stx)|[SMB1](#smbx)|[TYA](#txx)|[STA](#sta)|[TXS](#txx)||[STZ](#stz)|[STA](#sta)|[STZ](#stz)|[BBS1](#bbsx)|
+|Ax           |[LDY](#ldy)|[LDA](#lda)|[LDX](#ldx)||[LDY](#ldy)|[LDA](#lda)|[LDX](#ldx)|[SMB2](#smbx)|[TAY](#txx)|[LDA](#lda)|[TAX](#txx)||[LDY](#ldy)|[LDA](#lda)|[LDX](#ldx)|[BBS2](#bbsx)|
+|Bx           |[BCS](#bra)|[LDA](#lda)|[LDA](#lda)||[LDY](#ldy)|[LDA](#lda)|[LDX](#ldx)|[SMB3](#smbx)|[CLV](#clv)|[LDA](#lda)|[TSX](#txx)||[LDY](#ldy)|[LDA](#lda)|[LDX](#ldx)|[BBS3](#bbsx)|
+|Cx           |[CPY](#cpy)|[CMP](#cmp)|||[CPY](#cpy)|[CMP](#cmp)|[DEC](#dec)|[SMB4](#smbx)|[INY](#inc)|[CMP](#cmp)|[DEX](#dec)|[WAI](#wai)|[CPY](#cpy)|[CMP](#cmp)|[DEC](#dec)|[BBS4](#bbsx)|
+|Dx           |[BNE](#bra)|[CMP](#cmp)|[CMP](#cmp)|||[CMP](#cmp)|[DEC](#dec)|[SMB5](#smbx)|[CLD](#cld)|[CMP](#cmp)|[PHX](#pha)|[STP](#stp)||[CMP](#cmp)|[DEC](#dec)|[BBS5](#bbsx)|
+|Ex           |[CPX](#cpx)|[SBC](#sbc)|||[CPX](#cpx)|[SBC](#sbc)|[INC](#inc)|[SMB6](#smbx)|[INX](#inc)|[SBC](#sbc)|[NOP](#nop)||[CPX](#cpx)|[SBC](#sbc)|[INC](#inc)|[BBS6](#bbsx)|
+|Fx           |[BEQ](#bra)|[SBC](#sbc)|[SBC](#sbc)|||[SBC](#sbc)|[INC](#inc)|[SMB7](#smbx)|[SED](#sed)|[SBC](#sbc)|[PLX](#pla)|||[SBC](#sbc)|[INC](#inc)|[BBS7](#bbsx)|
 
-### By Function
+## Opcodes By Name
 
-| Load/Store      | Transfer    | Stack           | Logic           | Math        | Branch          | Flow            | Flags       |
-| --------------- | ----------- | -----------     | --------------- | ----------- | --------------- | --------------- | ----------- |
-| [LDA](#lda)     | [TAX](#tax) | [PHA](#pha)     | [ASL](#asl)     | [ADC](#adc) | [BCC](#bcc)     | [BRA](#bra)     | [CLC](#clc) |
-| [LDX](#ldx)     | [TAY](#tay) | [PHP](#php)     | [LSR](#lsr)     | [SBC](#sbc) | [BCS](#bcs)     | [JMP](#jmp)     | [CLD](#cld) |
-| [LDY](#ldy)     | [TSX](#tsx) | [PHX](#phx)[^4] | [ROL](#rol)     | [CMP](#cmp) | [BEQ](#beq)     | [JSR](#jsr)     | [CLI](#cli) |
-| [STA](#sta)     | [TXA](#txa) | [PHY](#phy)[^4] | [ROR](#ror)     | [CPX](#cpx) | [BMI](#bmi)     | [RTI](#rti)     | [CLV](#clv) |
-| [STX](#stx)     | [TXS](#txs) | [PLA](#pla)     | [AND](#and)     | [CPY](#cpy) | [BNE](#bne)     | [RTS](#rts)     | [SEC](#sec) |
-| [STY](#sty)     | [TYA](#tya) | [PLP](#plp)     | [BIT](#bit)     | [INC](#inc) | [BPL](#bpl)     | [BRK](#brk)     | [SED](#sed) |
-| [STZ](#stz)[^4] |             | [PLX](#plx)[^4] | [EOR](#eor)     | [INX](#inx) | [BVC](#bvc)     | [STP](#stp)[^4] | [SEI](#sei) |
-|                 |             | [PLY](#ply)[^4] | [ORA](#ora)     | [INY](#iny) | [BVS](#bvs)     | [WAI](#wai)[^4] |             |
-|                 |             |                 | [TRB](#trb)[^4] | [DEC](#dec) | [BBR](#bbr)[^4] [^5] |                 |             |
-|                 |             |                 | [TSB](#tsb)[^4] | [DEX](#dex) | [BBS](#bbs)[^4] [^5] |                 |             |
-|                 |             |                 | [NOP](#nop)     | [DEY](#dey) |                 |                 |             |
-|                 |             |                 | [RMB](#rmb)[^4] [^5] |             |                 |                 |             |
-|                 |             |                 | [SMB](#smb)[^4] [^5] |             |                 |                 |             |
+|     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |
+|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|
+| [ADC](#adc) | [AND](#and) | [ASL](#asl) | [BBRx](#bbrx) | [BBSx](#bbsx) | [BCC](#bra) | [BCS](#bra) | [BEQ](#bra) | [BIT](#bit) | [BMI](#bra) | [BNE](#bra) | [BPL](#bra) | [BRA](#bra) | [BRK](#brk) | [BVC](#bra) | [BVS](#bra) |
+| [CLC](#clc) | [CLD](#cld) | [CLI](#cli) | [CLV](#clv) | [CMP](#cmp) | [CPX](#cpx) | [CPY](#cpy) | [DEC](#dec) | [DEX](#dec) | [DEY](#dec) | [EOR](#eor) | [INC](#inc) | [INX](#inc) | [INY](#inc) | [JMP](#jmp) | [JSR](#jsr) |
+| [LDA](#lda) | [LDX](#ldx) | [LDY](#ldy) | [LSR](#lsr) | [NOP](#nop) | [ORA](#ora) | [PHA](#pha) | [PHP](#pha) | [PHX](#pha) | [PHY](#pha) | [PLA](#pla) | [PLP](#pla) | [PLX](#pla) | [PLY](#pla) | [RMBx](#rmbx) | [ROL](#rol) |
+| [ROR](#ror) | [RTI](#rti) | [RTS](#rts) | [SBC](#sbc) | [SEC](#sec) | [SED](#sed) | [SEI](#sei) | [SMBx](#smbx) | [STA](#sta) | [STP](#stp) | [STX](#stx) | [STY](#sty) | [STZ](#stz) | [TAX](#txx) | [TAY](#txx) | [TRB](#trb) |
+| [TSB](#tsb) | [TSX](#txx) | [TXA](#txx) | [TXS](#txx) | [TYA](#txx) | [WAI](#wai) |
 
-## Instructions
+## Opcodes By Category
+
+|     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |
+|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|
+|  Arithmetic | [ADC](#adc) | [SBC](#sbc) |
+|  Boolean | [AND](#and) | [EOR](#eor) | [ORA](#ora) |
+|  Bit Shift | [ASL](#asl) | [LSR](#lsr) | [ROL](#rol) | [ROR](#ror) |
+|  Branch | [BBRx](#bbrx) | [BBSx](#bbsx) |
+|  Test Bit | [BIT](#bit) | [TRB](#trb) | [TSB](#tsb) |
+|  Branching | [BCC](#bra) | [BCS](#bra) | [BEQ](#bra) | [BMI](#bra) | [BNE](#bra) | [BPL](#bra) | [BVC](#bra) | [BVS](#bra) | [BRA](#bra) | [JMP](#jmp) | [JSR](#jsr) | [RTI](#rti) | [RTS](#rts) |
+|  Misc | [BRK](#brk) | [NOP](#nop) | [STP](#stp) | [WAI](#wai) |
+|  Flags | [CLC](#clc) | [CLD](#cld) | [CLI](#cli) | [CLV](#clv) | [SEC](#sec) | [SED](#sed) | [SEI](#sei) |
+|  Compare | [CMP](#cmp) | [CPX](#cpx) | [CPY](#cpy) |
+|  Increment/Decrement | [DEC](#dec) | [DEX](#dec) | [DEY](#dec) | [INX](#inc) | [INY](#inc) | [INC](#inc) |
+|  Load Data | [LDA](#lda) | [LDX](#ldx) | [LDY](#ldy) |
+|  Stack | [PHA](#pha) | [PHP](#pha) | [PHX](#pha) | [PHY](#pha) | [PLA](#pla) | [PLP](#pla) | [PLX](#pla) | [PLY](#pla) |
+|  Bit Operations | [RMBx](#rmbx) | [SMBx](#smbx) |
+|  Store Data | [STA](#sta) | [STX](#stx) | [STY](#sty) | [STZ](#stz) |
+|  Transfer | [TAX](#txx) | [TXA](#txx) | [TAY](#txx) | [TYA](#txx) | [TSX](#txx) | [TXS](#txx) |
 
 ### ADC
 
 Add with Carry
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Immediate       | ADC #$44    | 2      | 2      |
-| Zero Page       | ADC $44     | 2      | 3      |
-| Zero Page,X     | ADC $44,X   | 2      | 4      |
-| Absolute        | ADC $4400   | 3      | 4      |
-| Absolute,X      | ADC $4400,X | 3      | 4[^1]  |
-| Absolute,Y      | ADC $4400,Y | 3      | 4[^1]  |
-| Indirect,X      | ADC ($44,X) | 2      | 6      |
-| Indirect,Y      | ADC ($44),Y | 2      | 5[^1]  |
 
-Add provided value to the A (accumulator) register. There is no way to add
-without a carry. Results depend on wether decimal mode is enabled.
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+ADC #$12     Immediate      $69   2     2     CZ---VN 
+ADC $12      Zero Page      $65   2     3     CZ---VN 
+ADC $12,X    Zero Page,X    $75   2     4     CZ---VN 
+ADC $1234    Absolute       $6D   3     4     CZ---VN 
+ADC $1234,X  Absolute,X     $7D   3     4     CZ---VN 
+ADC $1234,Y  Absolute,Y     $79   3     4     CZ---VN 
+ADC ($12,X)  Indirect,X     $61   2     6     CZ---VN 
+ADC ($12),Y  Indirect,Y     $71   2     5     CZ---VN 
+ADC ($12)    ZP Indirect    $72   2     5     CZ---VN +c
+```
 
-  - Sets C (Carry) flag is the result is larger than 255 (or 99 in decimal mode)
-  - Sets N (Negative) flag is the two's compliment result is negative (otherwise it is reset)
-  - Sets V (Overflow) if the two's compliment result exceeds -128 or +127 (otherwise it is reset)
-  - Sets Z (Zero) is the result is zero
+Add a number to the Accumulator and stores the result in A.
+
+Use the Carry (C) or Overflow (V) flags to determine whether the result was too
+large for an 8 bit number.
+
+If C is set before operation, then 1 will be added to the result.
+
+C is set when result is more than 255 ($FF)<br/>
+Z is set when result is zero<br/>
+V is set when signed result is too large. (Goes below -128 or above 127).<br/>
+N is set when result is negative (bit 7=1)<br/>
+
++c new for 65C02
+
+
+---
+[top](#)
+
 
 ### AND
 
-Logical Bitwise And
+Logical And
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Immediate       | AND #$44    | 2      | 2      |
-| Zero Page       | AND $44     | 2      | 3      |
-| Zero Page,X     | AND $44,X   | 2      | 4      |
-| Absolute        | AND $4400   | 3      | 4      |
-| Absolute,X      | AND $4400,X | 3      | 4[^1]  |
-| Absolute,Y      | AND $4400,Y | 3      | 4[^1]  |
-| Indirect,X      | AND ($44,X) | 2      | 6      |
-| Indirect,Y      | AND ($44),Y | 2      | 5[^1]  |
 
-Bitwise AND the provided value with the accumulator.
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+AND #$12     Immediate      $29   2     2     -Z----N 
+AND $12      Zero Page      $25   2     3     -Z----N 
+AND $12,X    Zero Page,X    $35   2     4     -Z----N 
+AND $1234    Absolute       $2D   3     4     -Z----N 
+AND $1234,X  Absolute,X     $3D   3     4     -Z----N 
+AND $1234,Y  Absolute,Y     $39   3     4     -Z----N 
+AND ($12,X)  Indirect,X     $21   2     6     -Z----N 
+AND ($12),Y  Indirect,Y     $31   2     5     -Z----N 
+AND ($12)    ZP Indirect    $32   2     5     -Z----N +c
+```
 
-  - Sets N (Negative) flag if the bit 7 of the result is 1, and otherewise clears it
-  - Sets Z (Zero) is the result is zero, and otherwise clears it
+Bitwise AND the provided value with the Accumulator.
+
+- Sets N (Negative) flag if the bit 7 of the result is 1, and otherewise
+clears it.
+- Sets Z (Zero) is the result is zero, and otherwise clears it<br/>
+
+`AND #$FF` will leave A unaffected (but still set the flags).<br/>
+`AND #$00` will clear A.<br/>
+`AND #$0F` will clear the high nibble of A, leaving a value of $00 to $0F
+in A.<br/>
+
+| M | A | Result |
+|---|---|--------|
+| 0 | 0 |   0    |
+| 0 | 1 |   0    |
+| 1 | 0 |   0    |
+| 1 | 1 |   1    |
+
+**Other Boolean Instructions:**<br/>
+[EOR](#eor) exclusive-OR<br/>
+[ORA](#ora) bitwise OR<br/>
+
++c new for 65C02
+
+
+---
+[top](#)
+
 
 ### ASL
 
 Arithmetic Shift Left
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Accumulator     | ASL         | 1      | 2      |
-| Zero Page       | ASL $44     | 2      | 5      |
-| Zero Page,X     | ASL $44,X   | 2      | 6      |
-| Absolute        | ASL $4400   | 3      | 6      |
-| Absolute,X      | ASL $4400,X | 3      | 7      |
 
-Shifts all bits to the left by one position. Unlike 
-[ROL](#rol), the bits do not rotate. 
-Instead a 0 is shifted into bit 0 and bit 7 is shifted 
-into the carry flag.
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+ASL A        Accumulator    $0A   1     2     CZ----N +c
+ASL $12      Zero Page      $06   2     5     CZ----N +c
+ASL $12,X    Zero Page,X    $16   2     6     CZ----N +c
+ASL $1234    Absolute       $0E   3     6     CZ----N +c
+ASL $1234,X  Absolute,X     $1E   3    6/7    CZ----N +p
+```
 
-Similar to [LSR](#lsr).
+Shifts all bits to the left by one position, through the Carry bit.
 
-### BBR
+The Carry bit is shifted into bit 0.<br/>
+Bit 7 is shifted into Carry.<br/>
 
-Branch If Bit Reset
+**Similar instructions:**<br/>
+[LSR](#lsr) is the opposite instruction and shifts to the right, through carry.<br/>
+[ROL](#rol) shifts from bit 7 to bit 0.<br/>
 
-| Addressing Mode | Usage          | Length | Cycles  |
-| --------------- | -------------  | ------ | ------- |
-| Zero Page       | BBRx $44,LABEL | 3      | 3-5[^2] |
++p Adds a cycle if ,X crosses a page boundary.<br/>
++c New for the 65C02<br/>
 
-Branch to LABEL if bit x of zero page address is 0 where x is the number 
-of the specific bit (0-7).
+
+---
+[top](#)
+
+
+### BBRx
+
+Branch on Bit Reset
+
+
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+BBR0 $1234   ZP Relative    $0F   3     5     ------- 
+BBR1 $1234   ZP Relative    $1F   3     5     ------- 
+BBR2 $1234   ZP Relative    $2F   3     5     ------- 
+BBR3 $1234   ZP Relative    $3F   3     5     ------- 
+BBR4 $1234   ZP Relative    $4F   3     5     ------- 
+BBR5 $1234   ZP Relative    $5F   3     5     ------- 
+BBR6 $1234   ZP Relative    $6F   3     5     ------- 
+BBR7 $1234   ZP Relative    $7F   3     5     ------- 
+```
+
+Branch to LABEL if bit x of zero page address is 0 where x is the number of the
+specific bit (0-7).
 
 Specific to the 65C02 (*unavailable on the 65C816*)
 
-#### Example (ca65)
+#### Example
 
-```
-  @check_flag:
-    BBR3 zeropage_flag, @flag_not_set
-  @flag_set:
+```asm
+  check_flag:
+    BBR3 zeropage_flag, flag_not_set
+  flag_set:
     NOP
     ...
-  @flag_not_set:
+  flag_not_set:
     NOP
     ...
 ```
@@ -158,22 +227,37 @@ The above BBR3 looks at value in zeropage_flag (here it's a label to an actual
 zero page address) and if bit 3 of the value is *zero* the branch would be
 taken to `@flag_not_set`.
 
-### BBS
 
-Branch If Bit Set
+---
+[top](#)
 
-| Addressing Mode | Usage          | Length | Cycles |
-| --------------- | -------------  | ------ | ------ |
-| Zero Page       | BBSx $44,LABEL | 3      | 5[^2]  |
 
-Branch to LABEL if bit x of zero page address is 1 where x is the number 
+### BBSx
+
+Branch on Bit Set
+
+
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+BBS0 $1234   ZP Relative    $8F   3     5     ------- 
+BBS1 $1234   ZP Relative    $9F   3     5     ------- 
+BBS2 $1234   ZP Relative    $AF   3     5     ------- 
+BBS3 $1234   ZP Relative    $BF   3     5     ------- 
+BBS4 $1234   ZP Relative    $CF   3     5     ------- 
+BBS5 $1234   ZP Relative    $DF   3     5     ------- 
+BBS6 $1234   ZP Relative    $EF   3     5     ------- 
+BBS7 $1234   ZP Relative    $FF   3     5     ------- 
+```
+
+
+Branch to LABEL if bit x of zero page address is 1 where x is the number
 of the specific bit (0-7).
 
 Specific to the 65C02 (*unavailable on the 65C816*)
 
 #### Example (ca65)
 
-```
+```asm
   @check_flag:
     BBS3 zeropage_flag, @flag_set
   @flag_not_set:
@@ -188,927 +272,1220 @@ The above BBR3 looks at value in zeropage_flag (here it's a label to an actual
 zero page address) and if bit 3 of the value is *zero* the branch would be
 taken to `@flag_set`.
 
-### BCC
 
-Branch If Carry Clear
+---
+[top](#)
 
-| Addressing Mode | Usage         | Length | Cycles   |
-| --------------- | ------------- | ------ | -------- |
-| Relative        | BCC LABEL     | 3      | 2-4 [^2] |
-
-Branch to LABEL if the carry flag (C) is clear. 
-
-### BCS
-
-Branch If Carry Set
-
-| Addressing Mode | Usage         | Length | Cycles   |
-| --------------- | ------------- | ------ | -------- |
-| Relative        | BCS LABEL     | 3      | 2-4 [^2] |
-
-Branch to LABEL if the carry flag (C) is set.
-
-### BEQ
-
-Branch If Equals
-
-| Addressing Mode | Usage         | Length | Cycles   |
-| --------------- | ------------- | ------ | -------- |
-| Relative        | BEQ LABEL     | 3      | 2-4 [^2] |
-
-Branch to LABEL if the zero flag (Z) is set. 
 
 ### BIT
 
-Test Bits
+Test Bit
 
-| Addressing Mode | Usage         | Length | Cycles |
-| --------------- | ------------- | ------ | ------ |
-| Zero Page       | BIT $44       | 2      | 3      |
-| Absolute        | BIT $4400     | 3      | 4      |
 
-  - Sets Z (Zero) flag based on an and'ing of value provided to the A (accumulator) register. 
-  - Sets N (Negative) flag to the value of bit 7 at the provided address.  
-  - Sets V (Overflow) flag to the value of bit 6 at the provided addres.  
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+BIT $12      Zero Page      $24   2     3     -Z---VN 
+BIT $1234    Absolute       $2C   3     4     -Z---VN 
+BIT #$12     Immediate      $89   2     2     -Z----- 
+BIT $12,X    Zero Page,X    $34   2     4     -Z---VN 
+BIT $1234,X  Absolute,X     $3C   3     4     -Z---VN 
+```
 
-### BMI
+- Sets Z (Zero) flag based on an AND of value provided to the Accumulator.
+- Sets N (Negative) flag to the value of bit 7 at the provided address.
+- Sets V (Overflow) flag to the value of bit 6 at the provided addres.
 
-Branch If Minus
 
-| Addressing Mode | Usage         | Length | Cycles   |
-| --------------- | ------------- | ------ | -------- |
-| Relative        | BMI LABEL     | 3      | 2-4 [^2] |
+---
+[top](#)
 
-Branch to LABEL if the negative flag (N) is set.
-
-### BNE
-
-Branch If Not-Equal
-
-| Addressing Mode | Usage         | Length | Cycles   |
-| --------------- | ------------- | ------ | -------- |
-| Relative        | BNE LABEL     | 3      | 2-4 [^2] |
-
-Branch to LABEL if the zero (Z) flag is clear.
-
-### BPL
-
-Branch If Positive
-
-| Addressing Mode | Usage         | Length | Cycles   |
-| --------------- | ------------- | ------ | -------- |
-| Relative        | BPL LABEL     | 3      | 2-4 [^2] |
-
-Branch to LABEL if the negative flag (N) is clear.
 
 ### BRA
 
-Branch Always
+Branch Instructions
 
-| Addressing Mode | Usage          | Length | Cycles   |
-| --------------- | -------------  | ------ | -------- |
-| Relative        | BRA LABEL  | 2      | 3-4 [^1] |
 
-Branch to LABEL no matter what. Essentially a relative jump
-which uses fewer bytes. Specific to the 65C02.
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+BCC $1234    Relative       $90   2    2/3    ------- +p Carry Clear
+BCS $1234    Relative       $B0   2    2/3    ------- +p Carry Set
+BEQ $1234    Relative       $F0   2    2/3    ------- +p Equal: Zero bit set
+BMI $1234    Relative       $30   2    2/3    ------- +p Negative bit set
+BNE $1234    Relative       $D0   2    2/3    ------- +p Not Equal: Zero bit clear
+BPL $1234    Relative       $10   2    2/3    ------- +p Negative bit not set
+BVC $1234    Relative       $50   2    2/3    ------- +p oVerflow Clear
+BVS $1234    Relative       $70   2    2/3    ------- +p oVerflow Set
+BRA $1234    Relative       $80   2    3/4    ------- +p Always
+```
+
+The branch instructions take the branch when the related flag is Set (1) or
+Clear (0).
+
+When combined with CMP, this is the 6502's "IF THEN" construct.
+
+```asm
+LDA $1234  ; Reads the value of address $1234
+CMP #$20   ; Compares it with the literal $20 (32)
+BEQ Match  ; If they are equal, move to the label "Match".
+```
+
+The operand is a _relative_ address, based on the Program Counter at the start
+of the next opcode. As a result, you can only branch 127 bytes forward or 128
+bytes back. However, most assemblers take a label or an address literal. So
+the assembled value will be computed based on the PC and the entered value.
+
+For example, if the PC is $1000, the statement `BCS $1023` will be `$B0 $21`.
+
++p: Execution takes one additional cycle when moving across a page boundary.
+
+
+---
+[top](#)
+
 
 ### BRK
 
-Break
+Break: Software Interrupt
 
-| Addressing Mode | Usage         | Length | Cycles   |
-| --------------- | ------------- | ------ | -------- |
-| Implied         | BRK           | 1      | 7        |
 
-Fires an NMI (non-maskable interrupt) and increments the
-program counter (PC) by 1. Useful in combination with RTI
-for debuggning.
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+BRK          Implied        $00   1     7     ---DB-- 
+```
 
-### BVC
+BRK is a software interrupt. With any interrupt several things happen:
 
-Branch On Overflow Clear
+1. The Program Counter is incremented by 2 bytes.
+2. The new PC and flags are pushed onto the stack.
+3. The B flag is set.
+4. The D (Decimal) flag is cleared, forcing the CPU into binary mode.
+5. The CPU reads the address from the NMI vector at $FFFE and jumps there.
 
-| Addressing Mode | Usage         | Length | Cycles   |
-| --------------- | ------------- | ------ | -------- |
-| Relative        | BVC LABEL     | 3      | 2-4 [^2] |
+On the X16, BRK will jump out of the running program to the machine monitor.
+You can then examine the state of the CPU registers and memory.
 
-Branch to LABEL if the overflow flag (V) is clear.
+The B flag is used to distinguish a BRK from an NMI. An interrupt triggered by
+asserting the NMI pin does not set the B flag, and so the X16 does a warm boot
+of BASIC, rather than jumping to MONitor.
 
-### BVS
 
-Branch On Overflow Set
+---
+[top](#)
 
-| Addressing Mode | Usage         | Length | Cycles   |
-| --------------- | ------------- | ------ | -------- |
-| Relative        | BVS LABEL     | 3      | 2-4 [^2] |
-
-Branch to LABEL if the overflow flag (V) is set.
 
 ### CLC
 
-Clear Carry Flag
+Clear Carry
 
-| Addressing Mode | Usage         | Length | Cycles   |
-| --------------- | ------------- | ------ | -------- |
-| Implied         | CLC           | 1      | 2        |
 
-Clears the carry (C) flag.
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+CLC          Implied        $18   1     2     C------ 
+```
+
+Clears the Carry flag. This is useful before ADC to prevent an extra 1 during
+addition. C is also often used in KERNAL routines to alter the operation of the
+routine or return certain information.
+
+
+---
+[top](#)
+
 
 ### CLD
 
 Clear Decimal Flag
 
-| Addressing Mode | Usage         | Length | Cycles   |
-| --------------- | ------------- | ------ | -------- |
-| Implied         | CLD           | 1      | 2        |
 
-Clears the decimal (D) flag, *disabling* binary-coded 
-decimal addition and subtraction.
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+CLD          Implied        $D8   1     2     ---D--- 
+```
+
+Clears the Decimal flag. This switches the CPU back to binary operation if it
+was previously in BCD mode.
+
+
+---
+[top](#)
+
 
 ### CLI
 
-Clear Interrupt Flag
+Clear Interrupt Disable
 
-| Addressing Mode | Usage         | Length | Cycles   |
-| --------------- | ------------- | ------ | -------- |
-| Implied         | CLI           | 1      | 2        |
 
-Clears the interrupt (I) flag, which in turn 
-**enables** maskable interrupts (IRQs).
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+CLI          Implied        $58   1     2     --I---- 
+```
+
+Clear Interrupt disable. This allows IRQ interrupts to proceed normally. NMI
+and RST are always enabled.
+
+Use SEI to disable interrupts
+
+
+---
+[top](#)
+
 
 ### CLV
 
-Clear Overflow Flag
+Clear oVerflow
 
-| Addressing Mode | Usage         | Length | Cycles   |
-| --------------- | ------------- | ------ | -------- |
-| Implied         | CLV           | 1      | 2        |
 
-Clears the overflow (V) flag, typically used with 
-two's compliment addition and subtraction.
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+CLV          Implied        $B8   1     2     -----V- 
+```
+
+Clear the Overflow (V) flag after an arithmetic operation, such as ADC or SBC.
+
+
+---
+[top](#)
+
 
 ### CMP
 
-Compare Accumulator
+Compare A to memory
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Immediate       | CMP #$44    | 2      | 2      |
-| Zero Page       | CMP $44     | 2      | 3      |
-| Zero Page,X     | CMP $44,X   | 2      | 4      |
-| Absolute        | CMP $4400   | 3      | 4      |
-| Absolute,X      | CMP $4400,X | 3      | 4[^1]  |
-| Absolute,Y      | CMP $4400,Y | 3      | 4[^1]  |
-| Indirect,X      | CMP ($44,X) | 2      | 6      |
-| Indirect,Y      | CMP ($44),Y | 2      | 5[^1]  |
 
-Compares the value in A (the accumulator) with the given
-value. It behaves as though a subtraction took place of
-the given value from the accumulator.
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+CMP #$12     Immediate      $C9   2     2     CZ----N 
+CMP $12      Zero Page      $C5   2     3     CZ----N 
+CMP $12,X    Zero Page,X    $D5   2     4     CZ----N 
+CMP $1234    Absolute       $CD   3     4     CZ----N 
+CMP $1234,X  Absolute,X     $DD   3     4     CZ----N 
+CMP $1234,Y  Absolute,Y     $D9   3     4     CZ----N 
+CMP ($12,X)  Indirect,X     $C1   2     6     CZ----N 
+CMP ($12),Y  Indirect,Y     $D1   2     5     CZ----N 
+CMP ($12)    ZP Indirect    $D2   2     5     CZ----N +c
+```
 
-  - Sets C (Carry) flag if the value in A is >= given value
-  - Clears C (Carry) flag if the value in A is < given value
-  - Sets Z (Zero) flag if the values are equal
-  - Clears Z (Zero) flag if the values are not equal
-  - Sets N (Negative) flag if value in A is < given value
+Compares the value in the Accumulator (A) with the given value. It sets flags
+based on subtracting A - _Value_.
+
+- Sets C (Carry) flag if the value in A is >= given value
+- Clears C (Carry) flag if the value in A is < given value
+- Sets Z (Zero) flag if the values are equal
+- Clears Z (Zero) flag if the values are not equal
+- Sets N (Negative) flag if value in A is < given value
+
+
+---
+[top](#)
+
 
 ### CPX
 
-Compare X Register
+Compare X to memory
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Immediate       | CPX #$44    | 2      | 2      |
-| Zero Page       | CPX $44     | 2      | 3      |
-| Absolute        | CPX $4400   | 3      | 4      |
 
-Compare value in X with given value. The behavior is the same
-as with [CMP](#cmp) only using the X register instead of
-A.
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+CPX #$12     Immediate      $E0   2     2     CZ----N 
+CPX $12      Zero Page      $E4   2     3     CZ----N 
+CPX $1234    Absolute       $EC   3     4     CZ----N 
+```
+
+Compares the value in the X register with the given value. It sets flags
+based on subtracting X - _Value_.
+
+- Sets C (Carry) flag if the value in X is >= given value
+- Clears C (Carry) flag if the value in X is < given value
+- Sets Z (Zero) flag if the values are equal
+- Clears Z (Zero) flag if the values are not equal
+- Sets N (Negative) flag if value in X is < given value
+
++c new for 65C02
+
+
+---
+[top](#)
+
 
 ### CPY
 
-Compare Y Register
+Compare Y to memory
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Immediate       | CPY #$44    | 2      | 2      |
-| Zero Page       | CPY $44     | 2      | 3      |
-| Absolute        | CPY $4400   | 3      | 4      |
 
-Compare value in Y with given value. The behavior is the same
-as with [CMP](#cmp) only using the Y register instead of
-A.
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+CPY #$12     Immediate      $C0   2     2     CZ----N 
+CPY $12      Zero Page      $C4   2     3     CZ----N 
+CPY $1234    Absolute       $CC   3     4     CZ----N 
+```
+
+Compares the value in the Y register with the given value. It sets flags
+based on subtracting Y - _Value_.
+
+- Sets C (Carry) flag if the value in Y is >= given value
+- Clears C (Carry) flag if the value in Y is < given value
+- Sets Z (Zero) flag if the values are equal
+- Clears Z (Zero) flag if the values are not equal
+- Sets N (Negative) flag if value in Y is < given value
+
+
+---
+[top](#)
+
 
 ### DEC
 
-Decrement Value In Memory
+Decrement Value
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Implied / A     | DEC         | 1      | 2      |
-| Zero Page       | DEC $44     | 2      | 5      |
-| Zero Page,X     | DEC $44,X   | 2      | 6      |
-| Absolute        | DEC $4400   | 3      | 6      |
-| Absolute,X      | DEC $4400,X | 3      | 7      |
 
-Decrement value in memory by one.
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+DEC $12      Zero Page      $C6   2     5     -Z----N 
+DEC $12,X    Zero Page,X    $D6   2     6     -Z----N 
+DEC $1234    Absolute       $CE   3     6     -Z----N 
+DEC $1234,X  Absolute,X     $DE   3     7     -Z----N 
+DEC A        Accumulator    $3A   1     2     -Z----N 
+DEX          Implied        $CA   1     2     -Z----N 
+DEY          Implied        $88   1     2     -Z----N 
+```
 
-  - Sets N (Negative) flag if the two's compliment value is negative
-  - Sets Z (Zero) flag is the value is zero
+Decrement value by one: this subtracts 1 from memory or the designated register,
+leaving the new value in its place.
 
-Implied/A mode is specific to 65C02 and 65C816. This operates on the 
-Accumulator (A)
+`DEC` with an operand operates on memory.
 
-### DEX
+`DEX` operates on the X register<br/>
+`DEY` operates on the Y register<br/>
+`DEC A` or `DEC` operates on the Accumulator.
 
-Decrement Value In X
+- Sets N (Negative) flag if the two's compliment value is negative
+- Sets Z (Zero) flag is the value is zero
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Implied         | DEX         | 1      | 2      |
+**Example**
 
-Decrement value in the X register by one.
+You can peform a 16-bit DEC by chaining two DECs together, testing the low
+byte before decrementing the high byte:
 
-  - Sets N (Negative) flag if the two's compliment value is negative
-  - Sets Z (Zero) flag is the value is zero
+```asm
+;16 bit decrement
+      LDA Num_Low
+      BNE Dec16_1
+      DEC Num_High
+LABEL DEC Num_Low
+```
 
-### DEY
 
-Decrement Value In Y
+---
+[top](#)
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Implied         | DEY         | 1      | 2      |
-
-Decrement value in the Y register by one.
-
-  - Sets N (Negative) flag if the two's compliment value is negative
-  - Sets Z (Zero) flag is the value is zero
 
 ### EOR
 
 Exclusive OR
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Immediate       | EOR #$44    | 2      | 2      |
-| Zero Page       | EOR $44     | 2      | 3      |
-| Zero Page,X     | EOR $44,X   | 2      | 4      |
-| Absolute        | EOR $4400   | 3      | 4      |
-| Absolute,X      | EOR $4400,X | 3      | 4[^1]  |
-| Absolute,Y      | EOR $4400,Y | 3      | 4[^1]  |
-| Indirect,X      | EOR ($44,X) | 2      | 6      |
-| Indirect,Y      | EOR ($44),Y | 2      | 5[^1]  |
 
-Perform an exclusive OR of the given value in A 
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+EOR #$12     Immediate      $49   2     2     -Z----N 
+EOR $12      Zero Page      $45   2     3     -Z----N 
+EOR $12,X    Zero Page,X    $55   2     4     -Z----N 
+EOR $1234    Absolute       $4D   3     4     -Z----N 
+EOR $1234,X  Absolute,X     $5D   3     4     -Z----N 
+EOR $1234,Y  Absolute,Y     $59   3     4     -Z----N 
+EOR ($12,X)  Indirect,X     $41   2     6     -Z----N 
+EOR ($12),Y  Indirect,Y     $51   2     5     -Z----N 
+EOR ($12)    ZP Indirect    $52   2     5     -Z----N +c
+```
+
+
+Perform an exclusive OR of the given value in A
 (the accumulator), storing the result in A.
 
 The exclusive OR version of [ORA](#ora).
 
-  - Sets N (Negative) flag if the two's compliment value is negative
-  - Sets Z (Zero) flag is the value is zero
+- Sets N (Negative) flag if the two's compliment value is negative
+- Sets Z (Zero) flag is the value is zero
 
-#### Truth Table
+Exclusive OR returns a 1 bit for each bit that is different in the values
+tested. It returns a 0 for each bit that is the same.
 
-|       | 0 | 1 |
-| ----- | - | - |
-| **0** | 0 | 1 | 
-| **1** | 1 | 0 |
+`EOR #$00` has no effect on A, but still sets the Z and N flags.<br/>
+`EOR #$FF` inverts the bits in A.<br/>
+
+| M | A | Result |
+|---|---|--------|
+| 0 | 0 |   0    |
+| 0 | 1 |   1    |
+| 1 | 0 |   1    |
+| 1 | 1 |   0    |
+
+**Other Boolean Instructions:**<br/>
+[ORA](#ora) bitwise OR<br/>
+[AND](#and) bitwise AND<br/>
+
++c new for 65C02
+
+
+---
+[top](#)
+
 
 ### INC
 
-Increment Value In Memory
+Increment Value
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Implied / A     | INC         | 1      | 2      |
-| Zero Page       | INC $44     | 2      | 5      |
-| Zero Page,X     | INC $44,X   | 2      | 6      |
-| Absolute        | INC $4400   | 3      | 6      |
-| Absolute,X      | INC $4400,X | 3      | 7      |
 
-Increment value in memory by one.
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+INX          Implied        $E8   1     2     -Z----N 
+INY          Implied        $C8   1     2     -Z----N 
+INC $12      Zero Page      $E6   2     5     -Z----N 
+INC $12,X    Zero Page,X    $F6   2     6     -Z----N 
+INC $1234    Absolute       $EE   3     6     -Z----N 
+INC $1234,X  Absolute,X     $FE   3     7     -Z----N 
+INC A        Accumulator    $1A   1     2     -Z----N 
+```
 
-  - Sets N (Negative) flag if the two's compliment value is negative
-  - Sets Z (Zero) flag is the value is zero
+Increment by one: this adds 1 to memory or the designated register, leaving the
+new value in its place.
 
-Implied/A mode is specific to 65C02 and 65C816. This operates on the 
-Accumulator (A)
+- Sets N (Negative) flag if the two's compliment value is negative
+- Sets Z (Zero) flag is the value is zero
 
-### INX
+`INC oper` operates on memory.<br/>
+`INX` operates on the X register.<br/>
+`INY` operates on the Y register.<br/>
+`INC A` or `INC` with no operand operates on the Accumulator.<br/>
 
-Increment Value In X
+**Example**
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Implied         | INX         | 1      | 2      |
+You can peform a 16-bit INC by chaining two INCs together, testing the low
+byte after incrementing it.
 
-Increment value in the X register by one.
+```asm
+;16 bit increment
+         INC Addr_Low
+         BNE Inc16_1
+         INC Addr_High
+Inc16_1: ...
+```
 
-  - Sets N (Negative) flag if the two's compliment value is negative
-  - Sets Z (Zero) flag is the value is zero
 
-### INY
+---
+[top](#)
 
-Increment Value In Y
-
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Implied         | INY         | 1      | 2      |
-
-Increment value in the Y register by one.
-
-  - Sets N (Negative) flag if the two's compliment value is negative
-  - Sets Z (Zero) flag is the value is zero
 
 ### JMP
 
-Jump To Memory Location
+Jump to new address
 
-| Addressing Mode | Usage         | Length | Cycles |
-| --------------- | -----------   | ------ | ------ |
-| Absolute        | JMP $4400     | 3      | 4      |
-| (Absolute,X)[^3]| JMP ($4400,X) | 3      | 6      |
-| Indirect        | JMP ($4400)   | 3      | 5      |
+
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+JMP $1234    Absolute       $4C   3     3     ------- 
+JMP ($1234)  Indirect       $6C   3     5     ------- 
+JMP $1234,X  Absolute,X     $7C   3     6     ------- 
+```
 
 Jump to specified memory location and begin execution
 from this point.
 
-Note for indirect jumps, never jump to a vector
-beginning on the last byte of a page.
+Note for indirect jumps: The CPU does not correctly retrieve the second byte
+of the pointer from the next page, so you should never use a pointer address
+on the last byte of a page. ie: $12FE.
 
 #### (Absolute,X) and Jump Tables
 
 (Absolute,X) is an addition mode for the 65C02 and is
-commonly used for implementing simpler jump tables as it
-avoids needing to have two tables for the low and high bytes.
+commonly used for implementing jump tables.
 
-Instead, we might have something like:
+So we might have something like:
 
-```
+```asm
 important_jump_table:
   .word routine1
   .word routine2
 ...
 
-LDX #$01
+LDX #$02
 JMP (important_jump_table,x)
 ```
 
-The above would jump to the address of `routine2`.
+The above would jump to the address of `routine2`, and is much faster than
+the old 6502 method of pushing the two bytes onto the stack and performing an
+RTS.
+
+
+---
+[top](#)
+
 
 ### JSR
 
 Jump to Subroutine
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Absolute        | JSR $4400   | 3      | 6      |
 
-Jump to a subroutine. Unlike [JMP](#jmp), JSR is commonly
-for jumping to a routine that will pass control back
-using [RTS](#rts) (return from subroutine) so that program
-execution continue at the instruction after the JSR.
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+JSR $1234    Absolute       $20   3     6     ------- 
+```
 
-In more technical terms, JSR pushes the address-1 of the
-next instruciton onto the stack before transferring control
-to the jumped to routine.
+Stores the address of the Program Counter to the stack.<br/>
+Jump to specified memory location and begin execution from this point.<br/>
+
+This is used to run subroutines in user programs, as well as running KERNAL
+routines. RTS is used at the end of the routine to return to the instruction
+immediately after the JSR.
+
+Be careful to always match JSR and RTS, as imbalanced JSR/RTS operations will
+either overflow or underflow the stack.
+
+
+---
+[top](#)
+
 
 ### LDA
 
-Load Accumulator
+Read memory to Accumulator
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Immediate       | LDA #$44    | 2      | 2      |
-| Zero Page       | LDA $44     | 2      | 3      |
-| Zero Page,X     | LDA $44,X   | 2      | 4      |
-| Absolute        | LDA $4400   | 3      | 4      |
-| Absolute,X      | LDA $4400,X | 3      | 4[^1]  |
-| Absolute,Y      | LDA $4400,Y | 3      | 4[^1]  |
-| Indirect,X      | LDA ($44,X) | 2      | 6      |
-| Indirect,Y      | LDA ($44),Y | 2      | 5[^1]  |
 
-Place the given value from memory into A (the accumulator).
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+LDA #$12     Immediate      $A9   2     2     -Z----N 
+LDA $12      Zero Page      $A5   2     3     -Z----N 
+LDA $12,X    Zero Page,X    $B5   2     4     -Z----N 
+LDA $1234    Absolute       $AD   3     4     -Z----N 
+LDA $1234,X  Absolute,X     $BD   3     4     -Z----N +p
+LDA $1234,Y  Absolute,Y     $B9   3     4     -Z----N +p
+LDA ($12,X)  Indirect,X     $A1   2     6     -Z----N 
+LDA ($12),Y  Indirect,Y     $B1   2     5     -Z----N +p
+LDA ($12)    ZP Indirect    $B2   2     5     -Z----N +c
+```
 
-  - Sets N (Negative) flag if the two's compliment value is negative
-  - Sets Z (Zero) flag is the value is zero
+Place the given value from memory into the accumulator (A).
+
+- Sets N (Negative) flag if the two's compliment value is negative
+- Sets Z (Zero) flag is the value is zero
+
++c New for the 65C02<br/>
++p add 1 cycle if addr+offset spans a page boundary<br/>
+
+
+---
+[top](#)
+
 
 ### LDX
 
-Load X
+Read memory to X Index Register
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Immediate       | LDX #$44    | 2      | 2      |
-| Zero Page       | LDX $44     | 2      | 3      |
-| Zero Page,Y     | LDX $44,Y   | 2      | 4      |
-| Absolute        | LDX $4400   | 3      | 4      |
-| Absolute,Y      | LDX $4400,Y | 3      | 4[^1]  |
+
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+LDX #$12     Immediate      $A2   2     2     -Z----N 
+LDX $12      Zero Page      $A6   2     3     -Z----N 
+LDX $12,Y    Zero Page,Y    $B6   2     4     -Z----N 
+LDX $1234    Absolute       $AE   3     4     -Z----N 
+LDX $1234,Y  Absolute,Y     $BE   3     4     -Z----N +p
+```
 
 Place the given value from memory into the X register.
 
-  - Sets N (Negative) flag if the two's compliment value is negative
-  - Sets Z (Zero) flag is the value is zero
+- Sets N (Negative) flag if the two's compliment value is negative
+- Sets Z (Zero) flag is the value is zero
+
++c New for the 65C02<br/>
++p add 1 cycle if addr+offset spans a page boundary<br/>
+
+
+---
+[top](#)
+
 
 ### LDY
 
-Load Y
+Read memory to Y Index Register
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Immediate       | LDY #$44    | 2      | 2      |
-| Zero Page       | LDY $44     | 2      | 3      |
-| Zero Page,X     | LDY $44,X   | 2      | 4      |
-| Absolute        | LDY $4400   | 3      | 4      |
-| Absolute,X      | LDY $4400,X | 3      | 4[^1]  |
+
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+LDY #$12     Immediate      $A0   2     2     -Z----N 
+LDY $12      Zero Page      $A4   2     3     -Z----N 
+LDY $12,X    Zero Page,X    $B4   2     4     -Z----N 
+LDY $1234    Absolute       $AC   3     4     -Z----N 
+LDY $1234,X  Absolute,X     $BC   3     4     -Z----N +p
+```
 
 Place the given value from memory into the Y register.
 
-  - Sets N (Negative) flag if the two's compliment value is negative
-  - Sets Z (Zero) flag is the value is zero
+- Sets N (Negative) flag if the two's compliment value is negative
+- Sets Z (Zero) flag is the value is zero
+
++c New for the 65C02<br/>
++p add 1 cycle if addr+offset spans a page boundary<br/>
+
+
+---
+[top](#)
+
 
 ### LSR
 
 Logical Shift Right
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Accumulator     | LSR         | 1      | 2      |
-| Zero Page       | LSR $44     | 2      | 5      |
-| Zero Page,X     | LSR $44,X   | 2      | 6      |
-| Absolute        | LSR $4400   | 3      | 6      |
-| Absolute,X      | LSR $4400,X | 3      | 7      |
 
-Shift all bits to the right one position. Unlike [ROR](#ror),
-the bits do not rotate. 0 is shifted into bit 7 and the 
-original value of bit 0 is shifted into the carry flag.
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+LSR A        Accumulator    $4A   1     2     -Z----N 
+LSR $12      Zero Page      $46   2     5     -Z----N 
+LSR $12,X    Zero Page,X    $56   2     6     -Z----N 
+LSR $1234    Absolute       $4E   3     6     -Z----N 
+LSR $1234,X  Absolute,X     $5E   3    6/7    -Z----N [^2]
+```
 
-Similar to [ASL](#asl).
+Shifts all bits to the right by one position, through the Carry bit.
+
+Bit 0 is shifted into Carry.<br/>
+The Carry bit is shifted into bit 7.<br/>
+
+**Similar instructions:**<br/>
+[ASL](#asl) is the opposite instruction, shifting to the left through carry<br/>
+[ROR](#ror) rotates bit 0 directly to bit 7.
+
++p Adds a cycle if ,X crosses a page boundary.<br/>
++c New for the 65C02<br/>
+
+
+---
+[top](#)
+
 
 ### NOP
 
-No-Op (Do nothing)
+No Operation
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Implied         | NOP         | 1      | 2      |
 
-Spend 2 cycles effectively doing nothing. This can be useful 
-under some circumstnaces as place-holder for code, or when 
-needing to manage precise timing or delay states.
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+NOP          Implied        $EA   1     2     ------- 
+```
 
-It can be used, for instance, to add a bit of delay when
-writing to the YM2151 chip (see 
+NOP simply does nothing for 2 clock cycles. No registers are affected, and no
+memory reads or writes occur. This can be used to delay the clock by 2 ticks.
+
+It's also a useful way to blank out unwanted instructions in memory or in
+a machine language program on disk. By changing the byte values of the opcode
+and operands to $EA, you can effectively cancel out an instruction.
+
+It is also useful for adding small delays to your code. For instance, to add a
+bit of delay when writing to the YM2151 chip (see
 [Chapter 11 - YM Write Procedure](X16%20Reference%20-%2011%20-%20Sound%20Programming.md#vera-psg-and-pcm-programming)).
+
+
+---
+[top](#)
+
 
 ### ORA
 
-Bitwise OR with the Accumulator
+Logical OR
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Immediate       | ORA #$44    | 2      | 2      |
-| Zero Page       | ORA $44     | 2      | 3      |
-| Zero Page,X     | ORA $44,X   | 2      | 4      |
-| Absolute        | ORA $4400   | 3      | 4      |
-| Absolute,X      | ORA $4400,X | 3      | 4[^1]  |
-| Absolute,Y      | ORA $4400,Y | 3      | 4[^1]  |
-| Indirect,X      | ORA ($44,X) | 2      | 6      |
-| Indirect,Y      | ORA ($44),Y | 2      | 5[^1]  |
 
-Perform a logical OR of the given value in A 
-(the accumulator), storing the result in A.
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+ORA #$12     Immediate      $09   2     2     -Z----N 
+ORA $12      Zero Page      $05   2     3     -Z----N 
+ORA $12,X    Zero Page,X    $15   2     4     -Z----N 
+ORA $1234    Absolute       $0D   3     4     -Z----N 
+ORA $1234,X  Absolute,X     $1D   3     4     -Z----N 
+ORA $1234,Y  Absolute,Y     $19   3     4     -Z----N 
+ORA ($12,X)  Indirect,X     $01   2     6     -Z----N 
+ORA ($12),Y  Indirect,Y     $11   2     5     -Z----N 
+ORA ($12)    ZP Indirect    $12   2     5     -Z----N +c
+```
 
-See [EOR](#eor) for the exclusive-OR version.
+Perform a logical OR of the given value in A
+(the Accumulator), storing the result in A.
 
-  - Sets N (Negative) flag if the two's compliment value is negative
-  - Sets Z (Zero) flag is the value is zero
+- Sets N (Negative) flag if the two's compliment value is negative
+- Sets Z (Zero) flag is the value is zero
+
+`OR #$00` has no effect on A, but still sets the Z and N flags.<br/>
+`OR #$FF` results in $FF.
+
+| M | A | Result |
+|---|---|--------|
+| 0 | 0 |   0    |
+| 0 | 1 |   1    |
+| 1 | 0 |   1    |
+| 1 | 1 |   1    |
+
+**Other Boolean Instructions:**<br/>
+[EOR](#eor) exclusive-OR<br/>
+[AND](#and) bitwise AND<br/>
+
++c new for 65C02
+
+
+---
+[top](#)
+
 
 ### PHA
 
-Push Accumulator (A) onto the Stack
+Push to stack
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Implied         | PHA         | 1      | 3      |
 
-Push the value in the accumulator onto the stack.
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+PHA          Implied        $48   1     3     ------- 
+PHP          Implied        $08   1     3     ------- 
+PHX          Implied        $DA   1     3     ------- 
+PHY          Implied        $5A   1     3     ------- 
+```
 
-### PHP
+Pushes a register to the stack.
 
-Push the status register (P) register onto the Stack
+This instruction copies the value in the affected register to the address
+of the stack pointer, then moves the stack pointer downward by one byte.
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Implied         | PHA         | 1      | 3      |
+Be careful to match Push and Pull operations so that you don't accidentally
+overflow or underflow the stack.
 
-Push the value in the status register (P) onto
-the stack. Useful as part of interrupt handling.
+PHP pushes the Flags, also called P for Program Status Register.
 
-### PHX
+The corresponding "Pull" instructions are [PLA](#pla), [PHP](#pla), [PHX](#pla),
+and [PHY](#pla).
 
-Push the X register register onto the Stack
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Implied         | PHX     | 1      | 3      |
+---
+[top](#)
 
-Push the value in the X onto the stack. Specific to the 65C02.
-
-### PHY
-
-Push the Y register register onto the Stack
-
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Implied         | PHY     | 1      | 3      |
-
-Push the value in the Y onto the stack. Specific to the 65C02.
 
 ### PLA
 
-Pop value from stack into the Accumulator (A)
+Pull from stack
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Implied         | PLA         | 1      | 4      |
 
-Pull/Pop the value on the stack and place into the accumulator.
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+PLA          Implied        $68   1     4     -Z----N 
+PLP          Implied        $28   1     4     CZIDBVN 
+PLX          Implied        $FA   1     4     -Z----N 
+PLY          Implied        $7A   1     4     -Z----N 
+```
 
-### PLP
+Pulls a value from the stack into a register.
 
-Pop value from stack into status register (P)
+This instruction moves the stack pointer up by one byte, then copies the value
+from the address of the stack pointer to the affected register.
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Implied         | PLP         | 1      | 4      |
+Be careful to match Push and Pull operations so that you don't accidentally
+overflow or underflow the stack.
 
-Pull/Pop the value on the stack and place into the 
-process status register (P).
+PLP pushes the Flags, also called P for Program Status Register.
 
-### PLX
+Use TXS or TSX to directly manage the stack pointer.
 
-Pop value from stack into the X register
+The corresponding "Push" instructions are [PHA](#pha), [PHP](#pha), [PHX](#pha),
+and [PHY](#pha).
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Implied         | PLX     | 1      | 4      |
 
-Pull/Pop the value on the stack and place into 
-the X register. Specific to the 65C02.
+---
+[top](#)
 
-### PLY
 
-Pop value from stack into the X register
+### RMBx
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Implied         | PLY     | 1      | 4      |
+Memory Bit Operations
 
-Pull/Pop the value on the stack and place into 
-the Y register. Specific to the 65C02.
 
-### RMB
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+RMB0 $12     Zero Page      $07   2     5     ------- +c -816
+RMB1 $12     Zero Page      $17   2     5     ------- +c -816
+RMB2 $12     Zero Page      $27   2     5     ------- +c -816
+RMB3 $12     Zero Page      $37   2     5     ------- +c -816
+RMB4 $12     Zero Page      $47   2     5     ------- +c -816
+RMB5 $12     Zero Page      $57   2     5     ------- +c -816
+RMB6 $12     Zero Page      $67   2     5     ------- +c -816
+RMB7 $12     Zero Page      $77   2     5     ------- +c -816
+```
 
-Reset Memory Bit
+Set bit x to 0 at the given zero page address where x is the number of the
+specified bit (0-7).
 
-| Addressing Mode | Usage          | Length | Cycles  |
-| --------------- | -------------  | ------ | ------- |
-| Zero Page       | RMBx $44       | 2      | 5       |
+Often used in conjunction with [BBR](#bbrx) and [BBS](#bbsx).
 
-Set bit x to 0 at the given zero page address where x is the number 
-of the specific bit (0-7).
++c new to the 65C02<br/>
+-816 _not available_ on the 65C816<br/>
 
-Often used in conjunction with [BBR](#bbr) and [BBS](#bbs).
 
-Specific to the 65C02 (*unavailable on the 65C816*)
+---
+[top](#)
+
 
 ### ROL
 
 Rotate Left
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Accumulator     | ROL         | 1      | 2      |
-| Zero Page       | ROL $44     | 2      | 5      |
-| Zero Page,X     | ROL $44,X   | 2      | 6      |
-| Absolute        | ROL $4400   | 3      | 6      |
-| Absolute,X      | ROL $4400,X | 3      | 7      |
 
-Rotate all bits to the left one position. The value in 
-the carry (C) flag is shifted into bit 0 and the original
-bit 7 is shifted into the carry (C).
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+ROL A        Accumulator    $2A   1     2     CZ----N 
+ROL $12      Zero Page      $26   2     5     CZ----N 
+ROL $12,X    Zero Page,X    $36   2     6     CZ----N 
+ROL $1234    Absolute       $2E   3     6     CZ----N 
+ROL $1234,X  Absolute,X     $3E   3    6/7    CZ----N +p
+```
 
-Unlike [ASL](#asl) the bits rotate rather than shift in
-a loop.
+Rotate all bits to the left one position. The value in the carry (C) flag is
+shifted into bit 0 and the original bit 7 is shifted into the carry (C).
+
+[ASL](#asl) rotates _through_ the Carry flag, effectively making a 9 bit shift.<br/>
+[ROR](#ror) rotates to the right<br/>
+
++p add one cycle when addr + x crosses a page boundary.
+
+
+---
+[top](#)
+
 
 ### ROR
 
 Rotate Right
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Accumulator     | ROR         | 1      | 2      |
-| Zero Page       | ROR $44     | 2      | 5      |
-| Zero Page,X     | ROR $44,X   | 2      | 6      |
-| Absolute        | ROR $4400   | 3      | 6      |
-| Absolute,X      | ROR $4400,X | 3      | 7      |
 
-Rotate all bits to the right one position. The value in 
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+ROR A        Accumulator    $6A   1     2     CZ----N 
+ROR $12      Zero Page      $66   2     5     CZ----N 
+ROR $12,X    Zero Page,X    $76   2     6     CZ----N 
+ROR $1234    Absolute       $7E   3     6     CZ----N 
+ROR $1234,X  Absolute,X     $6E   3    6/7    CZ----N [^2]
+```
+
+Rotate all bits to the right one position. The value in
 the carry (C) flag is shifted into bit 7 and the original
 bit 0 is shifted into the carry (C).
 
-Unlike [LSR](#lsr) the bits rotate rather than shift in a loop.
+[LSR](#lsr) rotates _through_ the Carry flag, effectively making a 9 bit shift.<br/>
+[ROL](#rol) rotates to the left.
+
+
+---
+[top](#)
+
 
 ### RTI
 
-Return From Interrupt
+Return from Interrupt
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Implied         | RTI         | 1      | 6      |
 
-Return from an interrupt by popping two values off the stack.
-The first is for the status register (P) followed by the program
-counter.
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+RTI          Implied        $40   1     6     ------- 
+```
+
+Return from an interrupt by popping three values off the stack.
+The first is for the status register (P) followed by the two bytes of the
+program counter.
 
 Note that unlike [RTS](#rts), the popped address is the actual
 return address (rather than address-1).
 
+
+---
+[top](#)
+
+
 ### RTS
 
-Return From Subroutine
+Return from Subroutine
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Implied         | RTS         | 1      | 6      |
 
-Typically used at the end of a subroutine. It jumps 
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+RTS          Implied        $60   1     6     ------- 
+```
+
+Typically used at the end of a subroutine. It jumps
 back to the address after the [JSR](#jsr) that called it
 by popping the top 2 bytes off the stack and transferring
 control to that address +1.
 
+
+---
+[top](#)
+
+
 ### SBC
 
-Subtract with Carry
+Subtract With Carry
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Immediate       | SBC #$44    | 2      | 2      |
-| Zero Page       | SBC $44     | 2      | 3      |
-| Zero Page,X     | SBC $44,X   | 2      | 4      |
-| Absolute        | SBC $4400   | 3      | 4      |
-| Absolute,X      | SBC $4400,X | 3      | 4[^1]  |
-| Absolute,Y      | SBC $4400,Y | 3      | 4[^1]  |
-| Indirect,X      | SBC ($44,X) | 2      | 6      |
-| Indirect,Y      | SBC ($44),Y | 2      | 5[^1]  |
 
-Subtract the provided value from A (accumulator) register. There is no way to 
-subtrack without a carry. Results depend on wether decimal mode is enabled.
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+SBC #$12     Immediate      $E9   2     2     CZ---VN 
+SBC $12      Zero Page      $E5   2     3     CZ---VN 
+SBC $12,X    Zero Page,X    $F5   2     4     CZ---VN 
+SBC $1234    Absolute       $ED   3     4     CZ---VN 
+SBC $1234,X  Absolute,X     $FD   3     4     CZ---VN 
+SBC $1234,Y  Absolute,Y     $F9   3     4     CZ---VN 
+SBC ($12,X)  Indirect,X     $E1   2     6     CZ---VN 
+SBC ($12),Y  Indirect,Y     $F1   2     5     CZ---VN 
+SBC ($12)    ZP Indirect    $F2   2     5     CZ---VN +c
+```
 
-If the carry flag (C) is cleared it means a borrow occurred.
+Subtract the operand from A and places the result in A.
+
+When Carry is 0, an additional 1 is subtracted.
+
+There is no "Subtract without carry". To do that, use SEC first to set the Carry
+flag.
+
+If D=1, subtraction is Binary Coded Decimal. If D=0 then subtraction is binary.
+
+C is clear when result is less than 0. (ie: Borrow took place)<br/>
+Z is set when result is zero<br/>
+V is set when signed result goes below -128 or above 127.<br/>
+N is set when result is negative (bit 7=1)<br/>
+
++c new for 65C02
+
+
+---
+[top](#)
+
 
 ### SEC
 
-Set Carry Flag
+Set Carry
 
-| Addressing Mode | Usage         | Length | Cycles   |
-| --------------- | ------------- | ------ | -------- |
-| Implied         | SEC           | 1      | 2        |
 
-Sets the carry (C) flag.
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+SEC          Implied        $38   1     2     C------ 
+```
+
+Sets the Carry flag. This is used before SBC to prevent an extra subtract. C
+is also often used in KERNAL routines to alter the operation of the routine
+or return certain information.
+
+
+---
+[top](#)
+
 
 ### SED
 
-Set Decimal Flag
+Set Decimal
 
-| Addressing Mode | Usage         | Length | Cycles   |
-| --------------- | ------------- | ------ | -------- |
-| Implied         | SED           | 1      | 2        |
 
-Set the decimal (D) flag, *enabling* binary-coded decimal
-addition and subtraction.
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+SED          Implied        $F8   1     2     ---D--- 
+```
+
+Sets the Decimal flag. This will put the CPU in BCD mode, which affects the
+behavior of ADC and SBC.
+
+In binary mode, adding 1 to $09 will set the Accumulator to $0F.<br/>
+In BCD mode, adding 1 to $09 will set the Accumulator to $10.<br/>
+
+Using BCD allows for easier conversion of binary numbers to decimal. BCD also
+allows for storing decimal numbers without loss of precision due to power-of-2
+rounding.
+
+
+---
+[top](#)
+
 
 ### SEI
 
-Set Interrupt Flag
+Set Interrupt Disable
 
-| Addressing Mode | Usage         | Length | Cycles   |
-| --------------- | ------------- | ------ | -------- |
-| Implied         | SEI           | 1      | 2        |
 
-Sets the interrupt (I) flag, which in turn **disables** maskable
-interrupts (IRQs).
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+SEI          Implied        $78   1     2     --I---- 
+```
 
-### SMB
+Sets or clears the Interrupt Disable flag. When I is set, the CPU will not
+execute IRQ interrupts, even if the line is asserted. Use CLI to re-enable
+interrupts.
+
+
+---
+[top](#)
+
+
+### SMBx
 
 Set Memory Bit
 
-| Addressing Mode | Usage          | Length | Cycles  |
-| --------------- | -------------  | ------ | ------- |
-| Zero Page       | SMBx $44       | 2      | 5       |
 
-Set bit x to 1 at the given zero page address where x is the number 
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+SMB0 $12     Zero Page      $87   2     5     ------- +c -816
+SMB1 $12     Zero Page      $97   2     5     ------- +c -816
+SMB2 $12     Zero Page      $A7   2     5     ------- +c -816
+SMB3 $12     Zero Page      $B7   2     5     ------- +c -816
+SMB4 $12     Zero Page      $C7   2     5     ------- +c -816
+SMB5 $12     Zero Page      $D7   2     5     ------- +c -816
+SMB6 $12     Zero Page      $E7   2     5     ------- +c -816
+SMB7 $12     Zero Page      $F7   2     5     ------- +c -816
+```
+
+Set bit x to 1 at the given zero page address where x is the number
 of the specific bit (0-7).
 
-Often used in conjunction with [BBR](#bbr) and [BBS](#bbs).
+Often used in conjunction with [BBR](#bbrx) and [BBS](#bbsx).
 
 Specific to the 65C02 (*unavailable on the 65C816*)
 
++c new to the 65C02<br/>
+-816 _not available_ on the 65C816<br/>
+
+
+---
+[top](#)
+
+
 ### STA
 
-Store Accumulator
+Store Accumulator contents to memory
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Zero Page       | STA $44     | 2      | 3      |
-| Zero Page,X     | STA $44,X   | 2      | 4      |
-| Absolute        | STA $4400   | 3      | 4      |
-| Absolute,X      | STA $4400,X | 3      | 5      |
-| Absolute,Y      | STA $4400,Y | 3      | 5      |
-| Indirect,X      | STA ($44,X) | 2      | 6      |
-| Indirect,Y      | STA ($44),Y | 2      | 6      |
 
-Place the given value from A (the accumulator) into memory.
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+STA $12      Zero Page      $85   2     3     ------- 
+STA $12,X    Zero Page,X    $95   2     4     ------- 
+STA $1234    Absolute       $8D   3     4     ------- 
+STA $1234,X  Absolute,X     $9D   3     5     ------- 
+STA $1234,Y  Absolute,Y     $99   3     5     ------- 
+STA ($12,X)  Indirect,X     $81   2     6     ------- 
+STA ($12),Y  Indirect,Y     $91   2     6     ------- 
+STA ($12)    ZP Indirect    $92   2     5     ------- +c
+```
+
+Place the given value from the accumulator (A) into memory.
+
++c new for 65C02
+
+
+---
+[top](#)
+
 
 ### STP
 
-Stop the Processor
+Stop
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Implied         | STP         | 1      | 3      |
 
-Stops the processor and places it in a lower power
-state until a hardware reset occurs. For the X16 emulator,
-when the debugger is enabled using the `-debug` command-line
-parameter, the STP instruction will break into the debugger
-automatically.
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+STP          Implied        $DB   1     3     ------- +c
+```
 
-Specific to the 65C02.
+Stops (or halts) the processor and places it in a lower power state until a
+hardware reset occurs. For the X16 emulator, when the debugger is enabled
+using the `-debug` command-line parameter, the STP instruction will break into
+the debugger automatically.
+
+If debugging is not enabled, the emulator will prompt the user to close the
+emulator or reset the emulation.
+
++c New for the 65C02
+
+
+---
+[top](#)
+
 
 ### STX
 
-Store X
+Save X Index Register contents to memory
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Zero Page       | STX $44     | 2      | 3      |
-| Zero Page,Y     | STX $44,Y   | 2      | 4      |
-| Absolute        | STX $4400   | 3      | 4      |
 
-Place the given value from X register into memory.
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+STX $12      Zero Page      $86   2     3     ------- 
+STX $12,Y    Zero Page,Y    $96   2     4     ------- 
+STX $1234    Absolute       $8E   3     4     ------- 
+```
+
+
+
+---
+[top](#)
+
 
 ### STY
 
-Store Y
+Save Y Index Register contents to memory
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Zero Page       | STY $44     | 2      | 3      |
-| Zero Page,X     | STY $44,Y   | 2      | 4      |
-| Absolute        | STY $4400   | 3      | 4      |
 
-Place the given value from Y register into memory.
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+STY $12      Zero Page      $84   2     3     ------- 
+STY $12,X    Zero Page,X    $94   2     4     ------- 
+STY $1234    Absolute       $8C   3     4     ------- 
+```
+
+
+
+---
+[top](#)
+
 
 ### STZ
 
-Store Zero
+Set memory to zero
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Zero Page       | STX $44     | 2      | 3      |
-| Zero Page,X     | STX $44,Y   | 2      | 4      |
-| Absolute        | STX $4400   | 3      | 4      |
-| Absolute,X      | STA $4400,X | 3      | 5      |
 
-Stores 0 into memory. A small optimization when needing
-to zero our a memory location instead of calling `LDA #$00`
-followed by a `STA $12`.
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+STZ $12      Zero Page      $64   2     3     ------- 
+STZ $12,X    Zero Page,X    $74   2     4     ------- 
+STZ $1234    Absolute       $9C   3     4     ------- 
+STZ $1234,X  Absolute,X     $9E   3     5     ------- 
+```
 
-Specific to the 65C02.
 
-### TAX
 
-Transfer A to X
+---
+[top](#)
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Implied         | TAX         | 1      | 2      |
-
-Transfer the value of the accumulator (A) to the X register.
-
-### TAY
-
-Transfer A to Y
-
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Implied         | TAY         | 1      | 2      |
-
-Transfer the value of the accumulator (A) to the Y register.
 
 ### TRB
 
-Test and Reset Bits
-
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Zero Page       | TRB $44     | 2      | 5      |
-| Absolute        | TRB $4400   | 3      | 6      |
-
-Performs a logical AND between the inverted bits of
-the accumulator and the value in memory and then
-stores the result back into the same memory location.
-
-  - Sets Z (Zero) flag if all bits from the AND are zero.
+Test and reset bit
 
 
-Specific to the 65C02.
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+TRB $12      Zero Page      $14   2     5     -Z----- 
+TRB $1234    Absolute       $1C   3     5     -Z----- 
+```
+
+Effectively an inverted AND between memory and the Accumulator. The bits that
+are 1 in the Accumulator are set to 0 in memory.
+
+- Sets Z (Zero) flag if all bits from the AND are zero.
+
+Example:
+
+```asm
+          ; Assume location $20 has a value of $11.
+LDA #$01  ; Load a bit mask of 0000 0001
+TRB $20   ; Apply the mask and reset bit 0
+          ; Location $20 now has a value of $10.
+```
+
+This is conceptually similar to
+
+```asm
+LDA #$01 ; We want to clear bit 1 of the data
+EOR #$FF ; Invert the mask, so $01 becomes $FE (1111 1110)
+AND $20  ; AND with memory, saving the result in .A
+STA $20  ; Store it back to memory.
+```
+
+
+---
+[top](#)
+
 
 ### TSB
 
-Test and Set Bits
+Test and set bit
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Zero Page       | TSB $44     | 2      | 5      |
-| Absolute        | TSB $4400   | 3      | 6      |
 
-Performs a logical OR between the bits of
-the accumulator and the value in memory and then
-stores the result back into the same memory location.
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+TSB $12      Zero Page      $04   2     5     -Z----- 
+TSB $1234    Absolute       $0C   3     5     -Z----- 
+```
 
-  - Sets Z (Zero) flag if all bits from the OR are zero.
+Performs an OR with each bit in the accumulator and memory.
+Each bit that is 1 in the Accumulator is set to 1 in memory. This is similar to
+an ORA operation, execpt that the result is stored in memory, not in A.
 
-Specific to the 65C02.
+The Z flag is set based on the final result of the operation, ie: the memory
+data is 0.
 
-### TSX
 
-Transfer Stack to X
+---
+[top](#)
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Implied         | TSX         | 1      | 2      |
 
-Pop a value off the stack and place it into X
+### Txx
 
-### TXA
+Transfer between registers
 
-Transfer X to A
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Implied         | TXA         | 1      | 2      |
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+TAX          Implied        $AA   1     2     -Z----N Copy from .A to .X
+TXA          Implied        $8A   1     2     -Z----N Copy from .X to .A
+TAY          Implied        $A8   1     2     -Z----N Copy from .A to .Y
+TYA          Implied        $98   1     2     -Z----N Copy from .Y to .A
+TSX          Implied        $BA   1     2     -Z----N Copy from Stack Pointer to .X
+TXS          Implied        $9A   1     2     ------- Copy from .X to Stack Pointer
+```
 
-Transfer the value of the X register to the accumulator (A).
+Copies data from one register to anohter.
 
-  - Sets N (Negative) flag if the two's compliment value is negative
-  - Sets Z (Zero) flag is the value is zero
+TSX and TSX copy between the Stack Pointer and the X register. This is the only
+way to directly control the Stack Pointer. To initialize the Stack Pointer to
+a specific address, you can use the following instructions.
 
-### TXS
+```asm
+LDX #$FF
+TXS
+```
 
-Transfer X to Stack
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Implied         | TXS         | 1      | 2      |
+---
+[top](#)
 
-Push the value from X onto the stack.
-
-### TYA
-
-Transfer Y to A
-
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Implied         | TYA         | 1      | 2      |
-
-Transfer the value of the Y register to the accumulator (A).
-
-  - Sets N (Negative) flag if the two's compliment value is negative
-  - Sets Z (Zero) flag is the value is zero
 
 ### WAI
 
-Wait for Interrupt
+Wait
 
-| Addressing Mode | Usage       | Length | Cycles |
-| --------------- | ----------- | ------ | ------ |
-| Implied         | WAI         | 1      | 3      |
 
-Puts the processor into a low power state until a 
-hardware interrupt occurs. The intterupt is processed 
-immediately since the processor is not otherwise running
-any instructions. This can improve interrupt timing.
+```text
+SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
+WAI          Implied        $CB   1     3     ------- +c
+```
+
+
+Effectively stops the processor until a hardware interrupt occurs. The intterupt
+is processed immediately, and execution resumes in the Interrupt handler.
+
+NMI, IRQ, and RST (Reset) will recover from the WAI condition.
+
+Normally, an instruction completes its operation before actually handling an
+interrupt. But if WAI has executed, the CPU does not need to defer the
+interrupt, and so the interrupt can be handled immediately.
+
++c New for the 65C02
+
+
+---
+[top](#)
+
 
 ## Status Flags
 
 Flags are stored in the P register. PHP and PLP can be used
 to directly manipulate this register. Otherwise the flags
-are used to indicate certain statuses and changed by 
+are used to indicate certain statuses and changed by
 various instructions.
 
 P-Register:
@@ -1124,17 +1501,13 @@ P-Register:
   Z = Zero  
   C = Carry  
 
-## Opcode Matrix
-
-(TODO)
-
 ## Replacement Macros for Bit Instructions
 
 Since `BBRx`, `BBSx`, `RMBx`, and `SMBx` should not be used to support a possible
 upgrade path to the 65816, here are some example macros that can be used to
 help convert existing software that may have been using these instructions:
 
-```
+```asm
 .macro bbs bit_position, data, destination
 	.if (bit_position = 7)
 		bit data
@@ -1178,27 +1551,27 @@ help convert existing software that may have been using these instructions:
 .endmacro
 ```
 
-The above is CA65 specific but the code should work similarly for other languages.
-The logic can also be used to if using an assembly language tool that does not have
-macro support with small changes.
+The above is CA65 specific but the code should work similarly for other
+languages. The logic can also be used to if using an assembly language tool
+that does not have macro support with small changes.
 
 ## Further Reading
 
-  * <http://www.6502.org/tutorials/6502opcodes.html>
-  * <http://6502.org/tutorials/65c02opcodes.html>
-  * <https://www.pagetable.com/c64ref/6502/?cpu=65c02>
-  * <http://www.oxyron.de/html/opcodesc02.html>
-  * <https://www.nesdev.org/wiki/Status_flags>
-  * <https://skilldrick.github.io/easy6502/>
-  * <https://www.westerndesigncenter.com/wdc/documentation/w65c02s.pdf>
-  * <https://www.westerndesigncenter.com/wdc/documentation/w65c816s.pdf>
-
+- <http://www.6502.org/tutorials/6502opcodes.html>
+- <http://6502.org/tutorials/65c02opcodes.html>
+- <https://www.pagetable.com/c64ref/6502/?cpu=65c02>
+- <http://www.oxyron.de/html/opcodesc02.html>
+- <https://www.nesdev.org/wiki/Status_flags>
+- <https://skilldrick.github.io/easy6502/>
+- <https://www.westerndesigncenter.com/wdc/documentation/w65c02s.pdf>
+- <https://www.westerndesigncenter.com/wdc/documentation/w65c816s.pdf>
 
 [^1]: Add 1 cycle if a page boundary is crossed  
-[^2]: Add 1 cycle if branch is taken on the same page, or 2 if it's taken to a different page  
+[^2]: Add 1 cycle if branch is taken on the same page, or 2 if it's taken to
+a different page  
 [^3]: 65C02 specific addressing mode  
-[^4]: 65C02 specific op-code
-[^5]: Not supported on the 65C816
+[^4]: 65C02 specific op-code  
+[^5]: Not supported on the 65C816  
 
 <!-- For PDF formatting -->
 <div class="page-break"></div>


### PR DESCRIPTION
This version of the 65C02 docs comes from a CSV file, run through a script, to create the documentation. 

I still need to do an opcode-by-opcode comparison with the WDC data sheet to confirm timings (especially page-crossing +1), but this version gives all the important stuff, including address modes, opcode numbers, and a description of each instruction. 

