### PR TITLE
Update memory map, add page break in 65C02, update actions versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y build-essential make fonts-dejavu
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Install md-to-pdf (npm)
         run: |
           npm i md-to-pdf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,13 +5,13 @@ jobs:
   build-pdf:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.9'
       - name: Install Dependencies
         run: sudo apt-get update && sudo apt-get install -y build-essential make fonts-dejavu
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
       - name: Install md-to-pdf (npm)
@@ -45,7 +45,7 @@ jobs:
           "X16 Reference - Appendix C - 65C02 Processor.md" \
           "X16 Reference - Appendix D - Official Expansion Cards.md" \
           | md-to-pdf --config-file .gh/config.js --stylesheet .gh/markdown.css > "artifacts/Commander X16 Programmer's Reference Guide.pdf"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: x16-docs-pdf
           path: artifacts/*

--- a/X16 Reference - 08 - Memory Map.md
+++ b/X16 Reference - 08 - Memory Map.md
@@ -45,7 +45,8 @@ Here is the ROM/Cartridge bank allocation:
 |11    |UTIL   |System Configuration (Date/Time, Display Preferences)  |
 |12    |BANNEX |BASIC Annex (code for some added BASIC functions)      |
 |13-14 |X16EDIT|The built-in text editor                               |
-|15-31 |–      |_[Currently unused]_                                   |
+|15    |BASLOAD|A transpiler that converts BASLOAD dialect to BASIC V2 |
+|16-31 |–      |_[Currently unused]_                                   |
 |32-255|–      |Cartridge RAM/ROM                                      |
 
 **Important**: The layout of the banks may still change.

--- a/X16 Reference - Appendix C - 65C02 Processor.md
+++ b/X16 Reference - Appendix C - 65C02 Processor.md
@@ -46,6 +46,9 @@ programs to malfunction on these computers.
 |Ex           |[CPX](#cpx) |[SBC](#sbc) |            |            |[CPX](#cpx) |[SBC](#sbc) |[INC](#inc) |[SMB6](#smbx)|[INX](#inc) |[SBC](#sbc) |[NOP](#nop) |            |[CPX](#cpx) |[SBC](#sbc) |[INC](#inc) |[BBS6](#bbsx)|
 |Fx           |[BEQ](#bra) |[SBC](#sbc) |[SBC](#sbc) |            |            |[SBC](#sbc) |[INC](#inc) |[SMB7](#smbx)|[SED](#sed) |[SBC](#sbc) |[PLX](#pla) |            |            |[SBC](#sbc) |[INC](#inc) |[BBS7](#bbsx)|
 
+<!-- For PDF formatting -->
+<div class="page-break"></div>
+
 ## Instructions By Name
 
 |               |               |               |               |               |               |               |               |               |               |               |               |               |               |               |               |


### PR DESCRIPTION
BASLOAD wasn't in the memory map
updated page breaks in 65C02
updated actions versions that were causing deprecation warnings.

Closes #142 