### PR TITLE
fix ROL, ROR, ASL, LSR errors

### DIFF
--- a/X16 Reference - Appendix C - 65C02 Processor.md
+++ b/X16 Reference - Appendix C - 65C02 Processor.md
@@ -46,6 +46,7 @@ programs to malfunction on these computers.
 |Ex           |[CPX](#cpx) |[SBC](#sbc) |            |            |[CPX](#cpx) |[SBC](#sbc) |[INC](#inc) |[SMB6](#smbx)|[INX](#inc) |[SBC](#sbc) |[NOP](#nop) |            |[CPX](#cpx) |[SBC](#sbc) |[INC](#inc) |[BBS6](#bbsx)|
 |Fx           |[BEQ](#bra) |[SBC](#sbc) |[SBC](#sbc) |            |            |[SBC](#sbc) |[INC](#inc) |[SMB7](#smbx)|[SED](#sed) |[SBC](#sbc) |[PLX](#pla) |            |            |[SBC](#sbc) |[INC](#inc) |[BBS7](#bbsx)|
 
+
 <!-- For PDF formatting -->
 <div class="page-break"></div>
 
@@ -79,6 +80,9 @@ programs to malfunction on these computers.
 | Bit Operations      | [RMBx](#rmbx)       | [SMBx](#smbx)       |                     |                     |                     |                     |                     |                     |                     |                     |                     |                     |                     |                     |                     |
 | Store Data          | [STA](#sta)         | [STX](#stx)         | [STY](#sty)         | [STZ](#stz)         |                     |                     |                     |                     |                     |                     |                     |                     |                     |                     |                     |
 | Transfer            | [TAX](#txx)         | [TXA](#txx)         | [TAY](#txx)         | [TYA](#txx)         | [TSX](#txx)         | [TXS](#txx)         |                     |                     |                     |                     |                     |                     |                     |                     |                     |
+
+<!-- For PDF formatting -->
+<div class="page-break"></div>
 
 ### ADC
 
@@ -175,14 +179,14 @@ ASL $8080    Absolute       $0E   3     6     CZ----N +c
 ASL $8080,X  Absolute,X     $1E   3    6/7    CZ----N +p
 ```
 
-Shifts all bits to the left by one position, through the Carry bit.
+Shifts all bits to the left by one position, moving 0 into the low bit.
 
-The Carry bit is shifted into bit 0.<br/>
-Bit 7 is shifted into Carry.<br/>
+0 is shifted into bit 0.<br/>
+Bit 7 is shifted to Carry.<br/>
 
 **Similar instructions:**<br/>
-[LSR](#lsr) is the opposite instruction and shifts to the right, through carry.<br/>
-[ROL](#rol) shifts from bit 7 to bit 0.<br/>
+[LSR](#lsr) is the opposite instruction and shifts to the right.<br/>
+[ROL](#rol) shifts left through Carry.
 
 +p Adds a cycle if ,X crosses a page boundary.<br/>
 +c New for the 65C02<br/>
@@ -827,14 +831,14 @@ LSR $8080    Absolute       $4E   3     6     -Z----N
 LSR $8080,X  Absolute,X     $5E   3    6/7    -Z----N [^2]
 ```
 
-Shifts all bits to the right by one position, through the Carry bit.
+Shifts all bits to the right by one position.
 
 Bit 0 is shifted into Carry.<br/>
-The Carry bit is shifted into bit 7.<br/>
+0 shifted into bit 7.<br/>
 
 **Similar instructions:**<br/>
-[ASL](#asl) is the opposite instruction, shifting to the left through carry<br/>
-[ROR](#ror) rotates bit 0 directly to bit 7.
+[ASL](#asl) is the opposite instruction, shifting to the left.<br/>
+[ROR](#ror) rotates bit 0 through Carry to bit 7.<br/>
 
 +p Adds a cycle if ,X crosses a page boundary.<br/>
 +c New for the 65C02<br/>
@@ -1020,8 +1024,8 @@ ROL $8080,X  Absolute,X     $3E   3    6/7    CZ----N +p
 Rotate all bits to the left one position. The value in the carry (C) flag is
 shifted into bit 0 and the original bit 7 is shifted into the carry (C).
 
-[ASL](#asl) rotates _through_ the Carry flag, effectively making a 9 bit shift.<br/>
-[ROR](#ror) rotates to the right<br/>
+[ASL](#asl) shifts left, moving 0 into bit 0
+[ROR](#ror) rotates to the right.
 
 +p add one cycle when addr + x crosses a page boundary.
 
@@ -1047,7 +1051,7 @@ Rotate all bits to the right one position. The value in
 the carry (C) flag is shifted into bit 7 and the original
 bit 0 is shifted into the carry (C).
 
-[LSR](#lsr) rotates _through_ the Carry flag, effectively making a 9 bit shift.<br/>
+[LSR](#lsr) shifts right, placing 0 into bit 7.
 [ROL](#rol) rotates to the left.
 
 

--- a/X16 Reference - Appendix C - 65C02 Processor.md
+++ b/X16 Reference - Appendix C - 65C02 Processor.md
@@ -108,10 +108,10 @@ large for an 8 bit number.
 
 If C is set before operation, then 1 will be added to the result.
 
-C is set when result is more than 255 ($FF)<br/>
-Z is set when result is zero<br/>
-V is set when signed result is too large. (Goes below -128 or above 127).<br/>
-N is set when result is negative (bit 7=1)<br/>
+C is set when result is more than 255 ($FF)  
+Z is set when result is zero  
+V is set when signed result is too large. (Goes below -128 or above 127).  
+N is set when result is negative (bit 7=1)  
 
 +c new for 65C02
 
@@ -141,12 +141,12 @@ Bitwise AND the provided value with the Accumulator.
 
 - Sets N (Negative) flag if the bit 7 of the result is 1, and otherewise
 clears it.
-- Sets Z (Zero) is the result is zero, and otherwise clears it<br/>
+- Sets Z (Zero) is the result is zero, and otherwise clears it  
 
-`AND #$FF` will leave A unaffected (but still set the flags).<br/>
-`AND #$00` will clear A.<br/>
+`AND #$FF` will leave A unaffected (but still set the flags).  
+`AND #$00` will clear A.  
 `AND #$0F` will clear the high nibble of A, leaving a value of $00 to $0F
-in A.<br/>
+in A.  
 
 | M | A | Result |
 |---|---|--------|
@@ -155,9 +155,9 @@ in A.<br/>
 | 1 | 0 |   0    |
 | 1 | 1 |   1    |
 
-**Other Boolean Instructions:**<br/>
-[EOR](#eor) exclusive-OR<br/>
-[ORA](#ora) bitwise OR<br/>
+**Other Boolean Instructions:**  
+[EOR](#eor) exclusive-OR  
+[ORA](#ora) bitwise OR  
 
 +c new for 65C02
 
@@ -181,15 +181,15 @@ ASL $8080,X  Absolute,X     $1E   3    6/7    CZ----N +p
 
 Shifts all bits to the left by one position, moving 0 into the low bit.
 
-0 is shifted into bit 0.<br/>
-Bit 7 is shifted to Carry.<br/>
+0 is shifted into bit 0.  
+Bit 7 is shifted to Carry.  
 
-**Similar instructions:**<br/>
-[LSR](#lsr) is the opposite instruction and shifts to the right.<br/>
+**Similar instructions:**  
+[LSR](#lsr) is the opposite instruction and shifts to the right.  
 [ROL](#rol) shifts left through Carry.
 
-+p Adds a cycle if ,X crosses a page boundary.<br/>
-+c New for the 65C02<br/>
++p Adds a cycle if ,X crosses a page boundary.  
++c New for the 65C02  
 
 
 ---
@@ -549,8 +549,8 @@ leaving the new value in its place.
 
 `DEC` with an operand operates on memory.
 
-`DEX` operates on the X register<br/>
-`DEY` operates on the Y register<br/>
+`DEX` operates on the X register  
+`DEY` operates on the Y register  
 `DEC A` or `DEC` operates on the Accumulator.
 
 - Sets N (Negative) flag if the two's compliment value is negative
@@ -603,8 +603,8 @@ The exclusive OR version of [ORA](#ora).
 Exclusive OR returns a 1 bit for each bit that is different in the values
 tested. It returns a 0 for each bit that is the same.
 
-`EOR #$00` has no effect on A, but still sets the Z and N flags.<br/>
-`EOR #$FF` inverts the bits in A.<br/>
+`EOR #$00` has no effect on A, but still sets the Z and N flags.  
+`EOR #$FF` inverts the bits in A.  
 
 | M | A | Result |
 |---|---|--------|
@@ -613,9 +613,9 @@ tested. It returns a 0 for each bit that is the same.
 | 1 | 0 |   1    |
 | 1 | 1 |   0    |
 
-**Other Boolean Instructions:**<br/>
-[ORA](#ora) bitwise OR<br/>
-[AND](#and) bitwise AND<br/>
+**Other Boolean Instructions:**  
+[ORA](#ora) bitwise OR  
+[AND](#and) bitwise AND  
 
 +c new for 65C02
 
@@ -645,10 +645,10 @@ new value in its place.
 - Sets N (Negative) flag if the two's compliment value is negative
 - Sets Z (Zero) flag is the value is zero
 
-`INC oper` operates on memory.<br/>
-`INX` operates on the X register.<br/>
-`INY` operates on the Y register.<br/>
-`INC A` or `INC` with no operand operates on the Accumulator.<br/>
+`INC oper` operates on memory.  
+`INX` operates on the X register.  
+`INY` operates on the Y register.  
+`INC A` or `INC` with no operand operates on the Accumulator.  
 
 **Example**
 
@@ -721,8 +721,8 @@ SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS
 JSR $8080    Absolute       $20   3     6     ------- 
 ```
 
-Stores the address of the Program Counter to the stack.<br/>
-Jump to specified memory location and begin execution from this point.<br/>
+Stores the address of the Program Counter to the stack.  
+Jump to specified memory location and begin execution from this point.  
 
 This is used to run subroutines in user programs, as well as running KERNAL
 routines. RTS is used at the end of the routine to return to the instruction
@@ -758,8 +758,8 @@ Place the given value from memory into the accumulator (A).
 - Sets N (Negative) flag if the two's compliment value is negative
 - Sets Z (Zero) flag is the value is zero
 
-+c New for the 65C02<br/>
-+p add 1 cycle if addr+offset spans a page boundary<br/>
++c New for the 65C02  
++p add 1 cycle if addr+offset spans a page boundary  
 
 
 ---
@@ -784,8 +784,8 @@ Place the given value from memory into the X register.
 - Sets N (Negative) flag if the two's compliment value is negative
 - Sets Z (Zero) flag is the value is zero
 
-+c New for the 65C02<br/>
-+p add 1 cycle if addr+offset spans a page boundary<br/>
++c New for the 65C02  
++p add 1 cycle if addr+offset spans a page boundary  
 
 
 ---
@@ -810,8 +810,8 @@ Place the given value from memory into the Y register.
 - Sets N (Negative) flag if the two's compliment value is negative
 - Sets Z (Zero) flag is the value is zero
 
-+c New for the 65C02<br/>
-+p add 1 cycle if addr+offset spans a page boundary<br/>
++c New for the 65C02  
++p add 1 cycle if addr+offset spans a page boundary  
 
 
 ---
@@ -833,15 +833,15 @@ LSR $8080,X  Absolute,X     $5E   3    6/7    -Z----N [^2]
 
 Shifts all bits to the right by one position.
 
-Bit 0 is shifted into Carry.<br/>
-0 shifted into bit 7.<br/>
+Bit 0 is shifted into Carry.  
+0 shifted into bit 7.  
 
-**Similar instructions:**<br/>
-[ASL](#asl) is the opposite instruction, shifting to the left.<br/>
-[ROR](#ror) rotates bit 0 through Carry to bit 7.<br/>
+**Similar instructions:**  
+[ASL](#asl) is the opposite instruction, shifting to the left.  
+[ROR](#ror) rotates bit 0 through Carry to bit 7.  
 
-+p Adds a cycle if ,X crosses a page boundary.<br/>
-+c New for the 65C02<br/>
++p Adds a cycle if ,X crosses a page boundary.  
++c New for the 65C02  
 
 
 ---
@@ -896,7 +896,7 @@ Perform a logical OR of the given value in A
 - Sets N (Negative) flag if the two's compliment value is negative
 - Sets Z (Zero) flag is the value is zero
 
-`OR #$00` has no effect on A, but still sets the Z and N flags.<br/>
+`OR #$00` has no effect on A, but still sets the Z and N flags.  
 `OR #$FF` results in $FF.
 
 | M | A | Result |
@@ -906,9 +906,9 @@ Perform a logical OR of the given value in A
 | 1 | 0 |   1    |
 | 1 | 1 |   1    |
 
-**Other Boolean Instructions:**<br/>
-[EOR](#eor) exclusive-OR<br/>
-[AND](#and) bitwise AND<br/>
+**Other Boolean Instructions:**  
+[EOR](#eor) exclusive-OR  
+[AND](#and) bitwise AND  
 
 +c new for 65C02
 
@@ -1000,8 +1000,8 @@ specified bit (0-7).
 
 Often used in conjunction with [BBR](#bbrx) and [BBS](#bbsx).
 
-+c new to the 65C02<br/>
--816 _not available_ on the 65C816<br/>
++c new to the 65C02  
+-816 _not available_ on the 65C816  
 
 
 ---
@@ -1125,10 +1125,10 @@ flag.
 
 If D=1, subtraction is Binary Coded Decimal. If D=0 then subtraction is binary.
 
-C is clear when result is less than 0. (ie: Borrow took place)<br/>
-Z is set when result is zero<br/>
-V is set when signed result goes below -128 or above 127.<br/>
-N is set when result is negative (bit 7=1)<br/>
+C is clear when result is less than 0. (ie: Borrow took place)  
+Z is set when result is zero  
+V is set when signed result goes below -128 or above 127.  
+N is set when result is negative (bit 7=1)  
 
 +c new for 65C02
 
@@ -1167,8 +1167,8 @@ SED          Implied        $F8   1     2     ---D---
 Sets the Decimal flag. This will put the CPU in BCD mode, which affects the
 behavior of ADC and SBC.
 
-In binary mode, adding 1 to $09 will set the Accumulator to $0F.<br/>
-In BCD mode, adding 1 to $09 will set the Accumulator to $10.<br/>
+In binary mode, adding 1 to $09 will set the Accumulator to $0F.  
+In BCD mode, adding 1 to $09 will set the Accumulator to $10.  
 
 Using BCD allows for easier conversion of binary numbers to decimal. BCD also
 allows for storing decimal numbers without loss of precision due to power-of-2
@@ -1220,8 +1220,8 @@ Often used in conjunction with [BBR](#bbrx) and [BBS](#bbsx).
 
 Specific to the 65C02 (*unavailable on the 65C816*)
 
-+c new to the 65C02<br/>
--816 _not available_ on the 65C816<br/>
++c new to the 65C02  
+-816 _not available_ on the 65C816  
 
 
 ---

--- a/X16 Reference - Appendix C - 65C02 Processor.md
+++ b/X16 Reference - Appendix C - 65C02 Processor.md
@@ -46,7 +46,6 @@ programs to malfunction on these computers.
 |Ex           |[CPX](#cpx) |[SBC](#sbc) |            |            |[CPX](#cpx) |[SBC](#sbc) |[INC](#inc) |[SMB6](#smbx)|[INX](#inc) |[SBC](#sbc) |[NOP](#nop) |            |[CPX](#cpx) |[SBC](#sbc) |[INC](#inc) |[BBS6](#bbsx)|
 |Fx           |[BEQ](#bra) |[SBC](#sbc) |[SBC](#sbc) |            |            |[SBC](#sbc) |[INC](#inc) |[SMB7](#smbx)|[SED](#sed) |[SBC](#sbc) |[PLX](#pla) |            |            |[SBC](#sbc) |[INC](#inc) |[BBS7](#bbsx)|
 
-
 <!-- For PDF formatting -->
 <div class="page-break"></div>
 
@@ -115,10 +114,8 @@ N is set when result is negative (bit 7=1)
 
 +c new for 65C02
 
-
 ---
 [top](#)
-
 
 ### AND
 
@@ -161,10 +158,8 @@ in A.
 
 +c new for 65C02
 
-
 ---
 [top](#)
-
 
 ### ASL
 
@@ -191,10 +186,8 @@ Bit 7 is shifted to Carry.
 +p Adds a cycle if ,X crosses a page boundary.  
 +c New for the 65C02  
 
-
 ---
 [top](#)
-
 
 ### BBRx
 
@@ -234,10 +227,8 @@ The above BBR3 looks at value in zeropage_flag (here it's a label to an actual
 zero page address) and if bit 3 of the value is *zero* the branch would be
 taken to `@flag_not_set`.
 
-
 ---
 [top](#)
-
 
 ### BBSx
 
@@ -254,7 +245,6 @@ BBS5 $20,$8080 ZP Relative    $DF   3     5     -------
 BBS6 $20,$8080 ZP Relative    $EF   3     5     ------- 
 BBS7 $20,$8080 ZP Relative    $FF   3     5     ------- 
 ```
-
 
 Branch to LABEL if bit x of zero page address is 1 where x is the number
 of the specific bit (0-7).
@@ -278,10 +268,8 @@ The above BBR3 looks at value in zeropage_flag (here it's a label to an actual
 zero page address) and if bit 3 of the value is *zero* the branch would be
 taken to `@flag_set`.
 
-
 ---
 [top](#)
-
 
 ### BIT
 
@@ -300,10 +288,8 @@ BIT $8080,X  Absolute,X     $3C   3     4     -Z---VN
 - Sets N (Negative) flag to the value of bit 7 at the provided address.
 - Sets V (Overflow) flag to the value of bit 6 at the provided addres.
 
-
 ---
 [top](#)
-
 
 ### BRA
 
@@ -342,10 +328,8 @@ For example, if the PC is $1000, the statement `BCS $1023` will be `$B0 $21`.
 
 +p: Execution takes one additional cycle when moving across a page boundary.
 
-
 ---
 [top](#)
-
 
 ### BRK
 
@@ -371,10 +355,8 @@ The B flag is used to distinguish a BRK from an NMI. An interrupt triggered by
 asserting the NMI pin does not set the B flag, and so the X16 does a warm boot
 of BASIC, rather than jumping to MONitor.
 
-
 ---
 [top](#)
-
 
 ### CLC
 
@@ -389,10 +371,8 @@ Clears the Carry flag. This is useful before ADC to prevent an extra 1 during
 addition. C is also often used in KERNAL routines to alter the operation of the
 routine or return certain information.
 
-
 ---
 [top](#)
-
 
 ### CLD
 
@@ -406,10 +386,8 @@ CLD          Implied        $D8   1     2     ---D---
 Clears the Decimal flag. This switches the CPU back to binary operation if it
 was previously in BCD mode.
 
-
 ---
 [top](#)
-
 
 ### CLI
 
@@ -425,10 +403,8 @@ and RST are always enabled.
 
 Use SEI to disable interrupts
 
-
 ---
 [top](#)
-
 
 ### CLV
 
@@ -441,10 +417,8 @@ CLV          Implied        $B8   1     2     -----V-
 
 Clear the Overflow (V) flag after an arithmetic operation, such as ADC or SBC.
 
-
 ---
 [top](#)
-
 
 ### CMP
 
@@ -472,10 +446,8 @@ based on subtracting A - _Value_.
 - Clears Z (Zero) flag if the values are not equal
 - Sets N (Negative) flag if value in A is < given value
 
-
 ---
 [top](#)
-
 
 ### CPX
 
@@ -499,10 +471,8 @@ based on subtracting X - _Value_.
 
 +c new for 65C02
 
-
 ---
 [top](#)
-
 
 ### CPY
 
@@ -524,10 +494,8 @@ based on subtracting Y - _Value_.
 - Clears Z (Zero) flag if the values are not equal
 - Sets N (Negative) flag if value in Y is < given value
 
-
 ---
 [top](#)
-
 
 ### DEC
 
@@ -569,10 +537,8 @@ byte before decrementing the high byte:
 LABEL DEC Num_Low
 ```
 
-
 ---
 [top](#)
-
 
 ### EOR
 
@@ -590,7 +556,6 @@ EOR ($20,X)  Indirect,X     $41   2     6     -Z----N
 EOR ($20),Y  Indirect,Y     $51   2     5     -Z----N 
 EOR ($20)    ZP Indirect    $52   2     5     -Z----N +c
 ```
-
 
 Perform an exclusive OR of the given value in A
 (the accumulator), storing the result in A.
@@ -619,10 +584,8 @@ tested. It returns a 0 for each bit that is the same.
 
 +c new for 65C02
 
-
 ---
 [top](#)
-
 
 ### INC
 
@@ -663,10 +626,8 @@ byte after incrementing it.
 Inc16_1: ...
 ```
 
-
 ---
 [top](#)
-
 
 ### JMP
 
@@ -707,10 +668,8 @@ The above would jump to the address of `routine2`, and is much faster than
 the old 6502 method of pushing the two bytes onto the stack and performing an
 RTS.
 
-
 ---
 [top](#)
-
 
 ### JSR
 
@@ -731,10 +690,8 @@ immediately after the JSR.
 Be careful to always match JSR and RTS, as imbalanced JSR/RTS operations will
 either overflow or underflow the stack.
 
-
 ---
 [top](#)
-
 
 ### LDA
 
@@ -761,10 +718,8 @@ Place the given value from memory into the accumulator (A).
 +c New for the 65C02  
 +p add 1 cycle if addr+offset spans a page boundary  
 
-
 ---
 [top](#)
-
 
 ### LDX
 
@@ -787,10 +742,8 @@ Place the given value from memory into the X register.
 +c New for the 65C02  
 +p add 1 cycle if addr+offset spans a page boundary  
 
-
 ---
 [top](#)
-
 
 ### LDY
 
@@ -813,10 +766,8 @@ Place the given value from memory into the Y register.
 +c New for the 65C02  
 +p add 1 cycle if addr+offset spans a page boundary  
 
-
 ---
 [top](#)
-
 
 ### LSR
 
@@ -843,10 +794,8 @@ Bit 0 is shifted into Carry.
 +p Adds a cycle if ,X crosses a page boundary.  
 +c New for the 65C02  
 
-
 ---
 [top](#)
-
 
 ### NOP
 
@@ -868,10 +817,8 @@ It is also useful for adding small delays to your code. For instance, to add a
 bit of delay when writing to the YM2151 chip (see
 [Chapter 11 - YM Write Procedure](X16%20Reference%20-%2011%20-%20Sound%20Programming.md#vera-psg-and-pcm-programming)).
 
-
 ---
 [top](#)
-
 
 ### ORA
 
@@ -912,10 +859,8 @@ Perform a logical OR of the given value in A
 
 +c new for 65C02
 
-
 ---
 [top](#)
-
 
 ### PHA
 
@@ -942,10 +887,8 @@ PHP pushes the Flags, also called P for Program Status Register.
 The corresponding "Pull" instructions are [PLA](#pla), [PHP](#pla), [PHX](#pla),
 and [PHY](#pla).
 
-
 ---
 [top](#)
-
 
 ### PLA
 
@@ -974,10 +917,8 @@ Use TXS or TSX to directly manage the stack pointer.
 The corresponding "Push" instructions are [PHA](#pha), [PHP](#pha), [PHX](#pha),
 and [PHY](#pha).
 
-
 ---
 [top](#)
-
 
 ### RMBx
 
@@ -1003,10 +944,8 @@ Often used in conjunction with [BBR](#bbrx) and [BBS](#bbsx).
 +c new to the 65C02  
 -816 _not available_ on the 65C816  
 
-
 ---
 [top](#)
-
 
 ### ROL
 
@@ -1024,15 +963,13 @@ ROL $8080,X  Absolute,X     $3E   3    6/7    CZ----N +p
 Rotate all bits to the left one position. The value in the carry (C) flag is
 shifted into bit 0 and the original bit 7 is shifted into the carry (C).
 
-[ASL](#asl) shifts left, moving 0 into bit 0
+[ASL](#asl) shifts left, moving 0 into bit 0  
 [ROR](#ror) rotates to the right.
 
 +p add one cycle when addr + x crosses a page boundary.
 
-
 ---
 [top](#)
-
 
 ### ROR
 
@@ -1051,13 +988,11 @@ Rotate all bits to the right one position. The value in
 the carry (C) flag is shifted into bit 7 and the original
 bit 0 is shifted into the carry (C).
 
-[LSR](#lsr) shifts right, placing 0 into bit 7.
-[ROL](#rol) rotates to the left.
-
+[LSR](#lsr) shifts right, placing 0 into bit 7.  
+[ROL](#rol) rotates to the left.  
 
 ---
 [top](#)
-
 
 ### RTI
 
@@ -1075,10 +1010,8 @@ program counter.
 Note that unlike [RTS](#rts), the popped address is the actual
 return address (rather than address-1).
 
-
 ---
 [top](#)
-
 
 ### RTS
 
@@ -1094,10 +1027,8 @@ back to the address after the [JSR](#jsr) that called it
 by popping the top 2 bytes off the stack and transferring
 control to that address +1.
 
-
 ---
 [top](#)
-
 
 ### SBC
 
@@ -1132,10 +1063,8 @@ N is set when result is negative (bit 7=1)
 
 +c new for 65C02
 
-
 ---
 [top](#)
-
 
 ### SEC
 
@@ -1150,10 +1079,8 @@ Sets the Carry flag. This is used before SBC to prevent an extra subtract. C
 is also often used in KERNAL routines to alter the operation of the routine
 or return certain information.
 
-
 ---
 [top](#)
-
 
 ### SED
 
@@ -1174,10 +1101,8 @@ Using BCD allows for easier conversion of binary numbers to decimal. BCD also
 allows for storing decimal numbers without loss of precision due to power-of-2
 rounding.
 
-
 ---
 [top](#)
-
 
 ### SEI
 
@@ -1192,10 +1117,8 @@ Sets or clears the Interrupt Disable flag. When I is set, the CPU will not
 execute IRQ interrupts, even if the line is asserted. Use CLI to re-enable
 interrupts.
 
-
 ---
 [top](#)
-
 
 ### SMBx
 
@@ -1223,10 +1146,8 @@ Specific to the 65C02 (*unavailable on the 65C816*)
 +c new to the 65C02  
 -816 _not available_ on the 65C816  
 
-
 ---
 [top](#)
-
 
 ### STA
 
@@ -1248,10 +1169,8 @@ Place the given value from the accumulator (A) into memory.
 
 +c new for 65C02
 
-
 ---
 [top](#)
-
 
 ### STP
 
@@ -1272,10 +1191,8 @@ emulator or reset the emulation.
 
 +c New for the 65C02
 
-
 ---
 [top](#)
-
 
 ### STX
 
@@ -1288,11 +1205,8 @@ STX $20,Y    Zero Page,Y    $96   2     4     -------
 STX $8080    Absolute       $8E   3     4     ------- 
 ```
 
-
-
 ---
 [top](#)
-
 
 ### STY
 
@@ -1305,11 +1219,8 @@ STY $20,X    Zero Page,X    $94   2     4     -------
 STY $8080    Absolute       $8C   3     4     ------- 
 ```
 
-
-
 ---
 [top](#)
-
 
 ### STZ
 
@@ -1323,11 +1234,8 @@ STZ $8080    Absolute       $9C   3     4     -------
 STZ $8080,X  Absolute,X     $9E   3     5     ------- 
 ```
 
-
-
 ---
 [top](#)
-
 
 ### TRB
 
@@ -1362,10 +1270,8 @@ AND $20  ; AND with memory, saving the result in .A
 STA $20  ; Store it back to memory.
 ```
 
-
 ---
 [top](#)
-
 
 ### TSB
 
@@ -1384,10 +1290,8 @@ an ORA operation, execpt that the result is stored in memory, not in A.
 The Z flag is set based on the final result of the operation, ie: the memory
 data is 0.
 
-
 ---
 [top](#)
-
 
 ### Txx
 
@@ -1414,10 +1318,8 @@ LDX #$FF
 TXS
 ```
 
-
 ---
 [top](#)
-
 
 ### WAI
 
@@ -1427,7 +1329,6 @@ Wait
 SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS    
 WAI          Implied        $CB   1     3     ------- +c
 ```
-
 
 Effectively stops the processor until a hardware interrupt occurs. The intterupt
 is processed immediately, and execution resumes in the Interrupt handler.
@@ -1440,10 +1341,8 @@ interrupt, and so the interrupt can be handled immediately.
 
 +c New for the 65C02
 
-
 ---
 [top](#)
-
 
 ## Status Flags
 


### PR DESCRIPTION
This fixes the description for the rotate/shift instructions. The original descriptions were incorrect.