### PR TITLE
BRK uses the IRQ vector, not NMI

### DIFF
--- a/X16 Reference - Appendix C - 65C02 Processor.md
+++ b/X16 Reference - Appendix C - 65C02 Processor.md
@@ -346,7 +346,7 @@ BRK is a software interrupt. With any interrupt several things happen:
 2. The new PC and flags are pushed onto the stack.
 3. The B flag is set.
 4. The D (Decimal) flag is cleared, forcing the CPU into binary mode.
-5. The CPU reads the address from the NMI vector at $FFFE and jumps there.
+5. The CPU reads the address from the IRQ vector at $FFFE and jumps there.
 
 On the X16, BRK will jump out of the running program to the machine monitor.
 You can then examine the state of the CPU registers and memory.


### PR DESCRIPTION
simple change to the BRK description