### PR TITLE
Change description of activity LED function to only on/off

### DIFF
--- a/X16 Reference - 12 - IO Programming.md
+++ b/X16 Reference - 12 - IO Programming.md
@@ -51,7 +51,7 @@ the PS/2 keyboard and mouse.
 | $01      | $01           | Hard reboot               |
 | $02      | $00           | Inject RESET              |
 | $03      | $00           | Inject NMI                |
-| $05      | $00/$01     | Activity LED off/on   |
+| $05      | $00/$FF     | Activity LED off/on   |
 | $07      | -              | Read from keyboard buffer |
 | $08      | $00..$FF     | Echo                      |
 | $18      | -              | Read ps2 status           |

--- a/X16 Reference - 12 - IO Programming.md
+++ b/X16 Reference - 12 - IO Programming.md
@@ -51,7 +51,7 @@ the PS/2 keyboard and mouse.
 | $01      | $01           | Hard reboot               |
 | $02      | $00           | Inject RESET              |
 | $03      | $00           | Inject NMI                |
-| $05      | $00..$FF     | Activity LED brightness   |
+| $05      | $00/$01     | Activity LED off/on   |
 | $07      | -              | Read from keyboard buffer |
 | $08      | $00..$FF     | Echo                      |
 | $18      | -              | Read ps2 status           |


### PR DESCRIPTION
The activity LED is not actually connected to a pin on the SMC that is able to do PWM output.