### PR TITLE
Update I2C/SMC header to match Dev Edition Rel 1.0

### DIFF
--- a/X16 Reference - 14 - Hardware.md
+++ b/X16 Reference - 14 - Hardware.md
@@ -255,6 +255,8 @@ There is no on-board speaker header. Instead, all audio is routed to the rear pa
 
 ### J9 I2C/SMC Header
 
+There are two different layouts for the SMC header. The first layout appears to be the curretnt (PRxxxxx) boards:
+
 | Desc             | Pin |   | Pin | Desc        |
 |-----------------:|----:|---|-----|-------------|
 | SMC MOSI/I2C SDA  |  1  |. .|  2  | +5V        |
@@ -262,6 +264,16 @@ There is no on-board speaker header. Instead, all audio is routed to the rear pa
 | SMC Reset         |  5  |. .|  6  | SMC RX     |
 | SMC SCK/I2C SCL   |  7  |. .|  8  | GND        |
 | 5VSB              |  9  |. .|  10 | GND        |
+
+This is the layout on the DEVxxxxx boards:
+
+| Desc             | Pin |   | Pin | Desc        |
+|-----------------:|----:|---|-----|-------------|
+| SMC MOSI/I2C SDA  |  1  |. .|  2  | +5VSB      |
+| RTC MFP           |  3  |. .|  4  | SMC TX     |
+| SMC Reset         |  5  |. .|  6  | SMC RX     |
+| SMC SCK/I2C SCL   |  7  |. .|  8  | GND        |
+| MISO              |  9  |. .|  10 | GND        |
 
 ### J10 Audio Option
 

--- a/X16 Reference - 14 - Hardware.md
+++ b/X16 Reference - 14 - Hardware.md
@@ -257,11 +257,11 @@ There is no on-board speaker header. Instead, all audio is routed to the rear pa
 
 | Desc             | Pin |   | Pin | Desc        |
 |-----------------:|----:|---|-----|-------------|
-| SMC MOSI/I2C SDA  |  1  |. .|  2  | 5V STANDBY |
+| SMC MOSI/I2C SDA  |  1  |. .|  2  | +5V        |
 | RTC MFP           |  3  |. .|  4  | SMC TX     |
 | SMC Reset         |  5  |. .|  6  | SMC RX     |
 | SMC SCK/I2C SCL   |  7  |. .|  8  | GND        |
-| SMC MISO          |  9  |. .|  10 | GND        |
+| 5VSB              |  9  |. .|  10 | GND        |
 
 ### J10 Audio Option
 


### PR DESCRIPTION
New version is what the silkscreen on the board says, and it matches what my multimeter says.

Or at least, the 5VSB pin is the same pin powering the microcontroller, it doesn't appear to be a dead short to +5VSB on the ATX header, so something odd seems to be going on.