### PR TITLE
Update the RTC Weekday value range

### DIFF
--- a/X16 Reference - 05 - KERNAL.md
+++ b/X16 Reference - 05 - KERNAL.md
@@ -672,7 +672,7 @@ Registers affected: .A .X .Y
 | r2L      | minutes (0-59)    |
 | r2H      | seconds (0-59)    |
 | r3L      | jiffies (0-59)    |
-| r3H      | weekday (0-6)     |
+| r3H      | weekday (1-7)     |
 
 Jiffies are 1/60th seconds.
 


### PR DESCRIPTION
This update to the KERNAL docs resolves a range error for the "weekday" value listed under the entry for `clock_set_date_time`; the range was updated from 0-6 to 1-7, per actual RTC functionality.

Closes #119