### PR TITLE
Rename bank CBDOS to CMDRDOS

### DIFF
--- a/X16 Reference - 08 - Memory Map.md
+++ b/X16 Reference - 08 - Memory Map.md
@@ -33,7 +33,7 @@ Here is the ROM/Cartridge bank allocation:
 |------|-------|-------------------------------------------------------|
 |0     |KERNAL |KERNAL operating system and drivers                    |
 |1     |KEYBD  |Keyboard layout tables                                 |
-|2     |CBDOS  |The computer-based CMDR-DOS for FAT32 SD cards         |
+|2     |CMDRDOS|The computer-based CMDR-DOS for FAT32 SD cards         |
 |3     |FAT32  |The FAT32 driver itself                                |
 |4     |BASIC  |BASIC interpreter                                      |
 |5     |MONITOR|Machine Language Monitor                               |


### PR DESCRIPTION
Quote from Discord by @mooinglemur:

"CBDOS is the old name, it was renamed to CMDR-DOS".

https://discord.com/channels/547559626024157184/549248089379307522/1285256940909363200