### PR TITLE
Appendix typos

### DIFF
--- a/X16 Reference - Appendix A - Sound.md
+++ b/X16 Reference - Appendix A - Sound.md
@@ -250,7 +250,7 @@ On the YM2151 using channel 0, plays in the current octave the sequence **C** **
 
 
 ### Octave
-* Synopsis: Explictly set the octave number for notes that follow
+* Synopsis: Explicitly set the octave number for notes that follow
 * Syntax: `O<0-7>`
 
 Example:

--- a/X16 Reference - Appendix C - 65C02 Processor.md
+++ b/X16 Reference - Appendix C - 65C02 Processor.md
@@ -12,7 +12,7 @@ The WDC65C02 CPU is a modern version of the MOS6502 with a few additional
 instructions and addressing modes and is capable of running at up to 14 MHz. On
 the Commander X16, it is clocked at 8 MHz.
 
-## A note about 65C816 Compatibilty
+## A note about 65C816 Compatibility
 
 The Commander X16 may be upgraded at some point to use the WDC 65C816 CPU.
 The 65C816 is mostly compatible with the 65C02, except for 4 instructions
@@ -137,7 +137,7 @@ AND ($20)    ZP Indirect    $32   2     5     N-----Z- +c
 
 Bitwise AND the provided value with the Accumulator.
 
-- Sets N (Negative) flag if the bit 7 of the result is 1, and otherewise
+- Sets N (Negative) flag if the bit 7 of the result is 1, and otherwise
 clears it.
 - Sets Z (Zero) is the result is zero, and otherwise clears it  
 
@@ -289,7 +289,7 @@ BIT $8080,X  Absolute,X     $3C   3     4+    NV----Z- +c +p
 
 - Sets Z (Zero) flag based on an AND of value provided to the Accumulator.
 - Sets N (Negative) flag to the value of bit 7 at the provided address (NOTE: not with immediate).
-- Sets V (Overflow) flag to the value of bit 6 at the provided addres (NOTE: not with immediate).
+- Sets V (Overflow) flag to the value of bit 6 at the provided address (NOTE: not with immediate).
 
 +p: Add 1 cycle if a page boundary is crossed when forming address.  
 +c: New for the 65C02  
@@ -541,7 +541,7 @@ leaving the new value in its place.
 
 #### 16-bit DEC Example
 
-You can peform a 16-bit DEC by chaining two DECs together, testing the low
+You can perform a 16-bit DEC by chaining two DECs together, testing the low
 byte before decrementing the high byte:
 
 ```asm
@@ -633,7 +633,7 @@ new value in its place.
 
 #### 16-bit INC Example
 
-You can peform a 16-bit INC by chaining two INCs together, testing the low
+You can perform a 16-bit INC by chaining two INCs together, testing the low
 byte after incrementing it.
 
 ```asm
@@ -1311,7 +1311,7 @@ TSB $8080    Absolute       $0C   3     5     ------Z- +c
 
 Performs an OR with each bit in the accumulator and memory.
 Each bit that is 1 in the Accumulator is set to 1 in memory. This is similar to
-an ORA operation, execpt that the result is stored in memory, not in A.
+an ORA operation, except that the result is stored in memory, not in A.
 
 The Z flag is set based on the final result of the operation, ie: the memory
 data is 0.
@@ -1335,7 +1335,7 @@ TSX          Implied        $BA   1     2     N-----Z- Copy from Stack Pointer t
 TXS          Implied        $9A   1     2     -------- Copy from .X to Stack Pointer
 ```
 
-Copies data from one register to anohter.
+Copies data from one register to another.
 
 TSX and TSX copy between the Stack Pointer and the X register. This is the only
 way to directly control the Stack Pointer. To initialize the Stack Pointer to
@@ -1358,7 +1358,7 @@ SYNTAX       MODE           HEX  LEN  CYCLES  FLAGS
 WAI          Implied        $CB   1     3     -------- +c
 ```
 
-Effectively stops the processor until a hardware interrupt occurs. The intterupt
+Effectively stops the processor until a hardware interrupt occurs. The interrupt
 is processed immediately, and execution resumes in the Interrupt handler.
 
 NMI, IRQ, and RST (Reset) will recover from the WAI condition.
@@ -1388,7 +1388,7 @@ P-Register:
   1 = Always 1  
   B = Interrupt Flag  
   D = Decimal Mode  
-  I = Interupts Disabled  
+  I = Interrupts Disabled  
   Z = Zero  
   C = Carry  
 

--- a/X16 Reference - Appendix D - Official Expansion Cards.md
+++ b/X16 Reference - Appendix D - Official Expansion Cards.md
@@ -6,15 +6,15 @@ This is just a stub as a proposal for how to document official expansion cards
 
 ## Serial/MIDI UART/Wavetable Expansion Card
 
-Kevin is desinging an EIA compliant UART expansion card which is capable of supporting 
+Kevin is designing an EIA compliant UART expansion card which is capable of supporting 
 standard serial as well as MIDI and even has a header to install wavetable cards.
 It uses the Texas Instruments [TL16C2550](https://www.ti.com/product/TL16C2550).
 
 ![Prototype Serial Card](images/Appendix_B/X16-Serial.png)
 
 As the card is still in development there are not any demos or code examples available,
-though the datasheet contains informaiton on how to set things up (see below). Kevin
-also provied [some information](https://discord.com/channels/547559626024157184/548715649065811989/1183801692878295101) on how to setup the card in his original announcement on the community Discord.
+though the datasheet contains information on how to set things up (see below). Kevin
+also provided [some information](https://discord.com/channels/547559626024157184/548715649065811989/1183801692878295101) on how to set up the card in his original announcement on the community Discord.
 
 <!-- For PDF formatting -->
 <div class="page-break"></div>

--- a/X16 Reference - Appendix E - Diagnostic Bank.md
+++ b/X16 Reference - Appendix E - Diagnostic Bank.md
@@ -28,7 +28,7 @@ It is also possible to jump directly to the diagnostic ROM bank from assembly.
 	jmp	$C000   ; Jump to beginning of diagnostic ROM
 ```  
 
-NOTE: The Diagnostic ROM is not able to return to BASIC or any program that has called. The only way to exit the Diagnostic ROM is by resetting or powercycling the system.
+NOTE: The Diagnostic ROM is not able to return to BASIC or any program that has called. The only way to exit the Diagnostic ROM is by resetting or power cycling the system.
 ### Non functional system
 If the Commander X16 is not able to boot into BASIC, the memory diagnostics can be started by keeping the power button pressed for about a second when powering on the system.  
 This will make the Commander X16 boot directly into the diagnostic ROM bank and start the memory diagnostics.
@@ -42,7 +42,7 @@ When the diagnostic ROM bank starts, it will use the activity LED to indicate th
 * OFF - for 3rd test of base memory ($0100-$9EFF)
 * ON - for 4th test of base memory ($0100-$9EFF)
   
-After the inital test of base memory, the number of available memory banks is tested, VERA is initialized and both the activity LED and the keyboard LEDs are used to indicate the progress.  
+After the initial test of base memory, the number of available memory banks is tested, VERA is initialized and both the activity LED and the keyboard LEDs are used to indicate the progress.  
 The keyboard LEDs are used as a binary counter:  
 | Num | Binary | Num Lock | Caps Lock | Scroll Lock |
 |-----|--------|----------|-----------|-------------|
@@ -58,7 +58,7 @@ The keyboard LEDs are used as a binary counter:
 #### Main test loop
 During the first test iteration, the keyboard LEDs will display 0 0 1  
 When the test is done, the activity light will blink once.  
-During the second test iteration, the keyboard LEDS will display 0 1 0  
+During the second test iteration, the keyboard LEDs will display 0 1 0  
 When the test is done, the activity light will blink once.  
 During the third test iteration, the keyboard LEDs will display 0 1 1  
 When the test is done, the activity light will blink once.  
@@ -81,14 +81,14 @@ When the initial test of base memory has succeeded and VERA is initialized, any 
   
 Even when tests are stopped, VERA output will still be switched between VGA and Composite/S-Video about every minute.
   
-The errorcodes on screen are as follows:
-![Errorcode definition](images/Appendix_E/mem-diag-error-code.jpg)
+The error codes on screen are as follows:
+![Error code definition](images/Appendix_E/mem-diag-error-code.jpg)
 
 ## Test algorithm
 ### Theory
-RAM diagnostics are performed with the March C- algorithm. This algorithm should be fairly godd at finding most common memory errors.  
+RAM diagnostics are performed with the March C- algorithm. This algorithm should be fairly good at finding most common memory errors.  
   
-In short, he aslgorithm is described as follows:
+In short, the algorithm is described as follows:
 1. Write 0 to all memory cells
 2. For each cell, check that it contains 0 and write 1 in ascending order
 3. For each cell, check that it contains 1 and write 0 in ascending order
@@ -105,21 +105,21 @@ To catch most memory errors, the following bit patterns are tested:
   
 The algorithm is then implemented in the following way:
 1. Write pattern to all memory addresses
-2. For each addres, check the patterna and write the inverted patterin in ascending order
+2. For each address, check the pattern and write the inverted pattern in ascending order
 3. For each address, check the inverted pattern and write the original pattern in ascending order
 4. For each address, check the original pattern and write the inverted pattern in descending order
 5. For eac address, check the inverted pattern and write the original pattern in descending order
 6. Check all addresses contain the original pattern
 ### Implementation
-When memory test starts, the first thing that happens is that zero-page is tested by it self. If this test passes, the rest of base memory is tested from $0100-$9EFF while ensuring that these tests do not affect zero-page memory.  
+When memory test starts, the first thing that happens is that zero-page is tested by itself. If this test passes, the rest of base memory is tested from $0100-$9EFF while ensuring that these tests do not affect zero-page memory.  
   
-When basememory has passed the initial test, zero-page is used for variables and stack pointer is initialized to enable pushing and popping of registers and function calls.  
+When base memory has passed the initial test, zero-page is used for variables and stack pointer is initialized to enable pushing and popping of registers and function calls.  
 VERA is initialized and the number of memory banks is tested.  
   
 All available memory banks are tested together as opposed to checking and clearing a single memory page at a time.  
 When all memory banks have been tested, the base memory $0200-$9EFF is tested again.  
   
-Memory banks and base memory is tested in continous loop.  
+Memory banks and base memory is tested in continuous loop.  
   
 If an error is detected, this is either communicated through the activity LED, if VERA has not yet been initialized, or by writing information about the error on the display.
 <!-- For PDF formatting -->

--- a/X16 Reference - Appendix F - 65C816 Processor.md
+++ b/X16 Reference - Appendix F - 65C816 Processor.md
@@ -37,7 +37,7 @@ relocation offer interesting multitasking opportunities.
 
 ## Compatibility with the 65C02
 
-The 65C916 CPU is generally compatible with the 65C02 instruction set, with the
+The 65C816 CPU is generally compatible with the 65C02 instruction set, with the
 exception  of the `BBRx`, `BBSx`, `RMBx`, and `SMBx` instructions. We recommend
 programmers avoid these instructions when writing X16 softwware, using the more
 conventional Boolean logic instructions, instead.
@@ -210,7 +210,7 @@ addresses (although they would be the same if .DP is set to $00.
 
 ## Vectors
 
-The 65816 has two different sets of interrupt vectors. In emulation mode, the
+The 65C816 has two different sets of interrupt vectors. In emulation mode, the
 vectors are the same as the 65C02. In native mode (.e = 0), the native vectors
 are used. This allows you to switch to the desired operation mode, based on the
 operating mode of your interrupt handlers.

--- a/X16 Reference - Appendix F - 65C816 Processor.md
+++ b/X16 Reference - Appendix F - 65C816 Processor.md
@@ -38,8 +38,8 @@ relocation offer interesting multitasking opportunities.
 ## Compatibility with the 65C02
 
 The 65C816 CPU is generally compatible with the 65C02 instruction set, with the
-exception  of the `BBRx`, `BBSx`, `RMBx`, and `SMBx` instructions. We recommend
-programmers avoid these instructions when writing X16 softwware, using the more
+exception of the `BBRx`, `BBSx`, `RMBx`, and `SMBx` instructions. We recommend
+programmers avoid these instructions when writing X16 software, using the more
 conventional Boolean logic instructions, instead.
 
 ## Registers
@@ -51,7 +51,7 @@ conventional Boolean logic instructions, instead.
 | Y         | Y Index          | .Y is mostly used as a counter and to offset addresses with Y indexed modes |
 | S         | Stack Pointer    | SP points to the next open position on the stack.                           |
 | DB or DBR | Data Bank        | Data bank is the default bank for operations that use a 16 bit address.     |
-| K or  PBR | Program Bank     | The default address for 16 bit JMP and JSR oprerations. Can only be set with a 24 bit JMP or JSR. |
+| K or  PBR | Program Bank     | The default address for 16 bit JMP and JSR operations. Can only be set with a 24 bit JMP or JSR. |
 | P         | Processor Status | The flags. |
 | PC        | Program Counter  | The address of the current CPU instruction |
 
@@ -75,7 +75,7 @@ The native mode flags are as follows:
   m = Memory width (0=16 bit, 1=8 bit)  
   x = Index register width (0=16 bit, 1=8 bit)  
   d = Decimal Mode  
-  i = Interupts Disabled  
+  i = Interrupts Disabled  
   z = Zero  
   c = Carry  
   e = Emulation Mode (0=65C02 mode, 1=65C816 mode)
@@ -91,14 +91,14 @@ Here are the 6502 and 65C02 registers, for comparison:
   1 = this bit is always 1  
   b = brk: set during a BRK instruction interrupt  
   d = Decimal Mode  
-  i = Interupts Disabled  
+  i = Interrupts Disabled  
   z = Zero  
   c = Carry  
 
 Note the missing **b** flag on the 65C816. This is no longer needed in native
 mode, since the BRK instruction now has its own vector. 
 
-The **e** flag can only accessed via the XCE instruction, which swaps Carry and
+The **e** flag can only be accessed via the XCE instruction, which swaps Carry and
 the Emulation flag.
 
 The other flags can all be manipulated with SEP and REP, and the various
@@ -141,7 +141,7 @@ When the **m** flag is *clear*, Accumulator operations and memory reads and writ
 will be 16-bit operations. The CPU reads two bytes at a time with LDA, writes
 two bytes at a time with STA, and all math involving .A is 16 bits wide.
 
-Likewise, whenn **x** is clear, the .X and .Y index registers are 16 bits wide.
+Likewise, when **x** is clear, the .X and .Y index registers are 16 bits wide.
 INX and INY will now count up to 65535, and indexed instructions like `LDA addr,X`
 can now cover 64K.
 
@@ -175,7 +175,7 @@ all _emulate_ 65C02 behavior when _set_.
 
 ## Address Modes
 
-The 65C816 now has 24 discinct address modes, although most are veriations on a
+The 65C816 now has 24 distinct address modes, although most are variations on a
 theme. Make note of the new syntax for Stack relative instructions (,S), the use
 of brackets for [24 bit indirect] addressing, and the fact that Zero Page has
 been renamed to Direct Page. This means that $0001 and $01 are now two different
@@ -194,7 +194,7 @@ addresses (although they would be the same if .DP is set to $00.
 | Direct Indirect Y Indexed       | ($12),Y   | Resolve pointer at $12 then offset by Y.                           |
 | Direct X Indexed Indirect       | ($12,X)   | Start at $12, offset by X, then read that address.                 |
 | Direct Indirect Long            | [$12]     | 24 bit pointer on Direct Page.                                     |
-| Direct Indrect Long Y Indexed   | [$12],Y   | Resolve address at $12, then offset by Y.                          |
+| Direct Indirect Long Y Indexed   | [$12],Y   | Resolve address at $12, then offset by Y.                          |
 | Indirect                        | ($1234)   | Read pointer at $1234 and get data from the resultant address      |
 | Indirect X Indexed              | ($1234,X) | Read pointer at $1234 offset by X, get data from resultant address |
 | Indirect Long                   | [$1234]   | Pointer is a 24-bit address.                                       |
@@ -413,7 +413,7 @@ In 8-bit mode, when you add two positive numbers that result in a sum
 higher than 127 or add two negative numbers that result in a sum below -128, you
 will get a signed overflow, and the v flag will be set.
 
-When the sum of the two numbers exceeeds 255 or 65535, then the Carry flag will
+When the sum of the two numbers exceeds 255 or 65535, then the Carry flag will
 be set. This bit can be added to the next higher byte with ADC #0.
 
 ```asm
@@ -766,7 +766,7 @@ Of course, due to wrapping of the 64K bank, this means that the entire 64K
 region is accessible. Values below 0 will simply wrap around and start from
 $FFFF, and values above $FFFF will wrap around to 0.
 
-Since this is a _relatve_ branch, that means code assembled with BRL, instead of
+Since this is a _relative_ branch, that means code assembled with BRL, instead of
 JMP, can be moved around in memory without the need for re-assembly.
 
 
@@ -962,7 +962,7 @@ BCC $1000
 As you can see, some comparisons will require two distinct branch instructions.
 
 Also, note that the Branch instructions (except BRL) require that the target
-address be within 128 bytes of the instruciton after the branch. If you need to
+address be within 128 bytes of the instruction after the branch. If you need to
 branch further, the usual method is to invert the branch instruction and use a
 JMP to take the branch.
 
@@ -1244,11 +1244,11 @@ JMP ($2034)      (abs)      6C  3   5           ........ .
 JMP ($2034,X)    (abs,X)    7C  3   6           ........ .
 ```
 
-Jump to a differnent address in memory, continuing program execution at the
+Jump to a different address in memory, continuing program execution at the
 specified address.
 
 Instructions like `JMP ($1234,X)` make it possible to branch to a selectable
-subroutine by setting X to the indesx into the vector table.
+subroutine by setting X to the index into the vector table.
 
 
 [[Opcodes](#instructions-by-opcode)] [[By Name](#instructions-by-name)] [[By Category](#instructions-by-category)]
@@ -1265,7 +1265,7 @@ JML $FEDCBA      long       5C  4   4           ........ .
 JMP [$2034]      [abs]      DC  3   6           ........ .
 ```
 
-Jump to a differnent address in memory, continuing program execution at the
+Jump to a different address in memory, continuing program execution at the
 specified address. JML accepts a 24-bit address, allowing the program to change
 program banks.
 
@@ -1304,7 +1304,7 @@ JSR ($2034,X)    (abs,X)    FC  3   8           ........ .
 ```
 
 Jumps to a new operating address in memory. Also pushes the return address to
-the stack, allowing an RTS insruction to pick up at the address following the
+the stack, allowing an RTS instruction to pick up at the address following the
 JSR.
 
 The [RTS](#rts) instruction returns to the instruction following JSR.
@@ -1555,7 +1555,7 @@ their own syntax rules.
 
 #### PEI
 
-**Push Effecive Indirect Address**
+**Push Effective Indirect Address**
 
 ```text
 SYNTAX           MODE       HEX LEN CYCLES      FLAGS   
@@ -1592,7 +1592,7 @@ PER LABEL        rel16      62  3   6           ........ .
 PER pushes the address _relative to the program counter_. This allows you to
 mark the current executing location and push that to the stack.
 
-When used in conjunctin with BRL, PER can form a reloatable JSR instruction.
+When used in conjunction with BRL, PER can form a relocatable JSR instruction.
 
 Consider the following ca65 macro:
 
@@ -1883,7 +1883,7 @@ SYNTAX           MODE       HEX LEN CYCLES      FLAGS
 REP #$20/#$1234  imm        C2  2   3           nvmxdizc .
 ```
 
-This clears (to 0) flags in the Program Status Byte. The 1 bits in the will be
+This clears (to 0) flags in the Program Status Byte. The 1 bit will be
 cleared in the flags, so REP #$30 will set the **a** and **x** bits low.
 
 
@@ -1985,7 +1985,7 @@ SYNTAX           MODE       HEX LEN CYCLES      FLAGS
 RTS              imp        60  1   6           ........ .
 ```
 
-Return to to a calling routine after a [JSR](#jsr).
+Return to a calling routine after a [JSR](#jsr).
 
 RTS reads a 2 byte address from the stack and loads that address into the
 Program Counter. The next instruction executed will then be the
@@ -2226,7 +2226,7 @@ byte of RAM.
 
 #### STZ
 
-**Store Sero to Memory**
+**Store Zero to Memory**
 
 ```text
 SYNTAX           MODE       HEX LEN CYCLES      FLAGS   
@@ -2352,10 +2352,10 @@ TRB does two things with one operation: it tests specified bits in a memory
 location, and it clears (resets) those bits after the test.
 
 First, TRB performs a logical AND between the memory address specified and the
-Accmulator. If the result of the AND is zero, the **z** flag will be set.
+Accumulator. If the result of the AND is zero, the **z** flag will be set.
 
 Second, TRB clears bits in the memory value based on the bit mask in the
-accmulator. Any bit that is 1 in .A will be changed to 0 in memory.
+accumulator. Any bit that is 1 in .A will be changed to 0 in memory.
 
 So to _clear_ a bit in a memory value, set that value to 1 in .A, like this:
 
@@ -2391,7 +2391,7 @@ TSB does two things with one operation: it tests specified bits in a memory
 location, and it clears (resets) those bits after the test.
 
 First, TSB performs a logical AND between the memory address specified and the
-Accmulator. If the result of the AND is zero, the **z** flag will be set.
+Accumulator. If the result of the AND is zero, the **z** flag will be set.
 
 TSB also _sets_ the bits that are 1 in the accumulator, similar to an OR
 operation.

--- a/X16 Reference - Appendix F - 65C816 Processor.md
+++ b/X16 Reference - Appendix F - 65C816 Processor.md
@@ -1709,7 +1709,7 @@ Note: the 6502 and 65C02 use bit 4 (**x** on the '816) for the Break flag. While
 **b** does get written to the stack in a BRK operation, bit 4 in .P always
 reflects the state of the 8-bit-index flag. Since the flags differ slightly in
 behavior, make sure your Interrupt handler code reads from the stack, not the .P
-bits, when dispatching a IRQ/BRK interrupt.
+bits, when dispatching an IRQ/BRK interrupt.
 
 
 [[Opcodes](#instructions-by-opcode)] [[By Name](#instructions-by-name)] [[By Category](#instructions-by-category)]

--- a/X16 Reference - Appendix G - ZSM File Format.md
+++ b/X16 Reference - Appendix G - ZSM File Format.md
@@ -6,7 +6,7 @@
 The Zsound suite of Commander X16 audio tools contains the original ZSM reference player, found at:  
 https://github.com/ZeroByteOrg/zsound/
 
-A newer, more flexible, and more recently maintained library with PCM support, ZSMKit, is avalable at:  
+A newer, more flexible, and more recently maintained library with PCM support, ZSMKit, is available at:  
 https://github.com/mooinglemur/ZSMKit/
 
 #### Current ZSM Revision: 1
@@ -102,7 +102,7 @@ Any offset values contained in the PCM data header block are relative to the beg
 
 This is a blob of PCM data with no internal formatting. Offsets into this blob are provided via the PCM header. The end of this blob will be the end of the ZSM file.
 
-## EXTCMD Channel Scifications
+## EXTCMD Channel Specifications
 
 Extension commands provide optional functionality within a ZSM music file. EXTCMD may be ignored by any player. EXTCMD defines 4 "channels" of message streams. Players may implement support for any, all, or none of the channels as desired. An EXTCMD may specify up to 63 bytes of data. If more data than this is required, then it must be broken up into multiple EXTCMDs.
 

--- a/X16 Reference - Appendix H - Onboard Upgrade Guide.md
+++ b/X16 Reference - Appendix H - Onboard Upgrade Guide.md
@@ -57,7 +57,7 @@ You may want to take a picture of the screen or write it down, for future refere
 
 #### 2.2 ROM/SMC/VERA (optional)
 - If you know your current version numbers (step 1), and do not care about rolling back, you can safely skip this step.
-- If you like to preserve the history, you can optionally dump the existing versions of ROM/SMC/VERA, for your own archival purposes. In particular, if your version is not a released full version (e.g. ROM prerelease), you may want to make a backup of this one (and give a head's up on Discord, #kernel).
+- If you like to preserve the history, you can optionally dump the existing versions of ROM/SMC/VERA, for your own archival purposes. In particular, if your version is not a released full version (e.g. ROM prerelease), you may want to make a backup of this one (and give a heads-up on Discord, #kernel).
 
 ##### 2.2.1 ROM (optional)
 If your ROM version is marked as release (and not prerelease), and your version is present in the ROM release page https://github.com/X16Community/x16-rom/releases/ , you can likely download your version from the release page should you ever want to roll back. If your version is marked as Prerelease (e.g. 8929A57+ or 33ACE3A4), it is harder to be certain that you can roll back, as those are not official releases. There exist a dump of a 8929A57+ ROM here: https://cx16forum.com/forum/viewtopic.php?p=31112 , although, in theory, there can exist different ROM versions with this number.
@@ -319,11 +319,11 @@ Run SMCBLD7.PRG. Check if "Boot v3 failsafe" is installed. If it is, and you pla
 Downgrade SMC using any tool
 - SMCUPDATE or x16-update
 - Note that SMC 45.1.0* or newer is needed if you want to use the bootloader afterwards
-- SMC older than R42 is indended for an incompatible hardware revision
+- SMC older than R42 is intended for an incompatible hardware revision
 
 ### Step 3: Downgrade ROM
 Downgrade ROM
-- ROM older than R42 is indended for an incompatible hardware revision
+- ROM older than R42 is intended for an incompatible hardware revision
 
 ### Step 4: Downgrade VERA
 Downgrade VERA


### PR DESCRIPTION
Some typo fixes in the appendices. I've tried to avoid subjective changes such as use of hyphenation. Given the technical nature of opcodes and whatnot, which I'm not an expert on, I suggest checking that it makes sense.