### PR TITLE
Editor: Mention Updated Japanese keyboard layout

### DIFF
--- a/X16 Reference - 03 - Editor.md
+++ b/X16 Reference - 03 - Editor.md
@@ -308,7 +308,7 @@ The following keyboard layouts are available from ROM. You can select one direct
 | `FI-FI`     | Finnish                             | [0000040B](http://kbdlayout.info/0000040B) |
 | `PT-BR`     | Portuguese (Brazil ABNT)            | [00000416](http://kbdlayout.info/00000416) |
 | `CS-CZ`     | Czech                               | [00000405](http://kbdlayout.info/00000405) |
-| `JA-JP`     | Japanese                            | [00000411](http://kbdlayout.info/00000411) |
+| `JA-JP`     | Japanese                            | [Custom IME](https://github.com/X16Community/x16-rom/pull/364) (since r49) |
 | `FR-FR`     | French                              | [0000040C](http://kbdlayout.info/0000040C) |
 | `DE-CH`     | Swiss German                        | [00000807](http://kbdlayout.info/00000807) |
 | `EN-US/DVO` | United States - Dvorak              | [00010409](http://kbdlayout.info/00010409) |


### PR DESCRIPTION
Docs still reference the old japanese layout. This PR changes that, so it points to the layout, that's going to be in future releases. Pre-r49 version of the layout is so useless it's probably not worth mentioning it in the revised documentation (and the new link does mention the behaviour of the old layout anyway).