### PR TITLE
Update upgrade guide

### DIFF
--- a/X16 Reference - Appendix H - Onboard Upgrade Guide.md
+++ b/X16 Reference - Appendix H - Onboard Upgrade Guide.md
@@ -20,8 +20,7 @@ These instructions will guide you how to update your X16 firmware from any previ
 |-----------------|---------|------------|--------------------------------------------------------------------|
 | ROM             | R48     | 2024-09-06 | https://github.com/X16Community/x16-rom/releases/tag/r48           |
 | SMC             | 48.0.0  | 2024-12-23 | https://github.com/X16Community/x16-smc/releases/tag/r48.0.0       |
-| VERA            | 47.0.2  | 2024-03-30 | https://github.com/X16Community/vera-module/releases/tag/v47.0.2   |
-| VERA (prelim)   | 48.0.1  | 2024-12-26 | https://github.com/X16Community/vera-module/releases/tag/v48.0.1   |
+| VERA            | 48.0.1  | 2025-01-08 | https://github.com/X16Community/vera-module/releases/tag/v48.0.1   |
 | SMC bootloader  | 3       | 2024-09-13 | https://github.com/X16Community/x16-smc-bootloader/releases/tag/v3 |
 
 
@@ -101,13 +100,11 @@ If your version is not archived (e.g. ROM prerelease), you may want to make a ba
 To organize multiple ROM and VERA versions on the SD card, you may e.g. add folders with version numbers, and place firmware inside.
 
 #### Downloads:
-- VERA 47.0.2 (release)
-	- https://github.com/X16Community/vera-module/releases/tag/v47.0.2
-		- Download Assets -> VERA_47.0.2.BIN and FLASHVERA.PRG
-- VERA 48.0.1 (prerelease)
+- VERA 48.0.1
 	- https://github.com/X16Community/vera-module/releases/tag/v48.0.1
 		- Download Assets -> VERA_48.0.1.BIN
-		- Use FLASHVERA.PRG from 47.0.2 assets
+    - https://github.com/mooinglemur/flashvera/releases/tag/v0.2
+		- Download Assets -> FLASHVERA.PRG
 - ROM R48
 	- https://github.com/X16Community/x16-rom/releases/tag/r48
 		- Download Assets -> Release.R48.ROM.Image.zip
@@ -141,10 +138,10 @@ To organize multiple ROM and VERA versions on the SD card, you may e.g. add fold
 @$
 ```
 
-### Step 4: Update VERA to 47.0.2
+### Step 4: Update VERA to 48.0.1
 VERA have best backward compatibility, and should be flashed first.
-- 47.0.2 supports at least ROM 47 prerelease, and probably older ROMs as well.
-- Release page: https://github.com/X16Community/vera-module/releases/tag/v47.0.2
+- 48.0.1 supports at least ROM 47 prerelease, and probably older ROMs as well.
+- Release page: https://github.com/X16Community/vera-module/releases/tag/v48.0.1
 - Follow instructions on release page to program VERA.
 
 ```
@@ -154,10 +151,6 @@ RUN
 ```
 
 - After programming, restart machine and type `HELP` to verify VERA version.
-
-#### VERA 48.0.1 prerelease
-- You can optionally install VERA 48.0.1, which is currently a prerelease. Same procedure as for 47.0.2.
-- Release page: https://github.com/X16Community/vera-module/releases/tag/v48.0.1
 
 ### Step 5: Update ROM to R48
 - Minimum SMC version: 43.0.0
@@ -242,7 +235,7 @@ With Boot V3 failsafe installed, you have a fallback mechanism in case SMC firmw
 ## Appendix: Release history
 | Date       | ROM               | SMC     | VERA   | SMC bootloader | Notes                           |
 |------------|-------------------|---------|--------|----------------|---------------------------------|
-| 2024-12-26 |                   |         | 48.0.1 |                | XOR Sawtooth + bus stability    |
+| 2025-01-08 |                   |         | 48.0.1 |                | XOR Sawtooth + bus stability    |
 | 2024-12-23 |                   | 48.0.0  |        |                | Kbd initstate, read fuse++      |
 | 2024-09-13 |                   |         |        | 3              | Boot v3, with failsafe          |
 | 2024-09-06 | R48               |         |        |                | Release R48 ("Cadmium")         |

--- a/X16 Reference - Appendix H - Onboard Upgrade Guide.md
+++ b/X16 Reference - Appendix H - Onboard Upgrade Guide.md
@@ -285,7 +285,7 @@ This is based on feedback from users on Discord, and is very approximate. If you
 | VERA            | 0.3.2                | 2023-11-20 |                                                                                                                  |
 | SMC bootloader  | 2 (bad)*             | 2023-10-04 |                                                                                                                  |
 
-### PR00901 to PR?????
+### PR00901 to PR01000
 
 | Firmware        | Version | Date       | Link                                                               |
 |-----------------|---------|------------|--------------------------------------------------------------------|
@@ -294,14 +294,24 @@ This is based on feedback from users on Discord, and is very approximate. If you
 | VERA            | 47.0.2  | 2024-03-30 | https://github.com/X16Community/vera-module/releases/tag/v47.0.2   |
 | SMC bootloader  | 2       | 2023-10-04 | https://github.com/X16Community/x16-smc-bootloader/releases/tag/v2 |
 
+### PR01001 to PR?????
+
+| Firmware        | Version | Date       | Link                                                               |
+|-----------------|---------|------------|--------------------------------------------------------------------|
+| ROM             | R48     | 2024-09-06 | https://github.com/X16Community/x16-rom/releases/tag/r48           |
+| SMC             | 47.2.3  | 2024-07-05 | https://github.com/X16Community/x16-smc/releases/tag/r47.2.3       |
+| VERA            | 47.0.2  | 2024-03-30 | https://github.com/X16Community/vera-module/releases/tag/v47.0.2   |
+| SMC bootloader  | 2       | 2023-10-04 | https://github.com/X16Community/x16-smc-bootloader/releases/tag/v2 |
+
 ### Some stock versions
-| Machine | ROM                  | SMC     | VERA  | SMC bootloader |
-|---------|----------------------|---------|-------|----------------|
-| PR00015 | R47pre git 8929A57+* |         |       |                |
-| PR00102 | R47pre git 8929A57+* | 45.1.0* | 0.3.2 | 2 (bad)*       |
-| PR00499 | R47pre git 33ACE3A4* |         |       |                |
-| PR00831 | R47pre git 33ACE3A4* | 45.1.0* | 0.3.2 | 2 (bad)*       |
-| PR00923 |                      | 47.0.0  |       |                |
+| Machine | ROM                  | SMC     | VERA   | SMC bootloader |
+|---------|----------------------|---------|--------|----------------|
+| PR00015 | R47pre git 8929A57+* |         |        |                |
+| PR00102 | R47pre git 8929A57+* | 45.1.0* | 0.3.2  | 2 (bad)*       |
+| PR00499 | R47pre git 33ACE3A4* |         |        |                |
+| PR00831 | R47pre git 33ACE3A4* | 45.1.0* | 0.3.2  | 2 (bad)*       |
+| PR00923 |                      | 47.0.0  |        |                |
+| PR01011 | R48                  | 47.2.3  | 47.0.2 | 2              |
 
 </p>
 </details>


### PR DESCRIPTION
Update the upgrade guide:
- Mention 48.0.1 as latest VERA release
- List stock version numbers for boards newer than PR01000

@mooinglemur