### PR TITLE
Add warning regarding appending to file

### DIFF
--- a/X16 Reference - 04 - BASIC.md
+++ b/X16 Reference - 04 - BASIC.md
@@ -334,6 +334,8 @@ BSAVE "MYFILE.BIN,S,A",8,2,$A000,$B000
 
 The above example appends a region of memory from $A000 through and including $AFFF, stopping before $B000.  Running both of the above examples in succession will result in a file MYFILE.BIN 12KiB in size.
 
+**Warning:** Appending to file involves a risk of corrupting the file system of the SD card! See [Appending to file](X16%20Reference%20-%2013%20-%20Working%20with%20CMDR-DOS.md#appending-to-file).
+
 ### BVLOAD
 
 **TYPE: Command**  

--- a/X16 Reference - 05 - KERNAL.md
+++ b/X16 Reference - 05 - KERNAL.md
@@ -526,6 +526,10 @@ For example:
 `SETLFS` and `SETNAM` both need to be called prior other file comamnds, such as `OPEN` or
 `SAVE`.
 
+To append to a file, add `,?,A` to the filename. See [Appending to file](X16%20Reference%20-%2013%20-%20Working%20with%20CMDR-DOS.md#appending-to-file).
+
+**Warning:** Appending to file involves a risk of corrupting the file system of the SD card! See [Appending to file](X16%20Reference%20-%2013%20-%20Working%20with%20CMDR-DOS.md#appending-to-file).
+
 ---
 
 ### Memory

--- a/X16 Reference - 13 - Working with CMDR-DOS.md
+++ b/X16 Reference - 13 - Working with CMDR-DOS.md
@@ -238,28 +238,28 @@ The Commodore DOS side and the FAT32 side are well separated, so a lot of code c
 
 Or the core feature set, these are the supported functions:
 
-| Feature                   | Syntax                        | Supported | Comment |
-|---------------------------|-------------------------------|-----------|---------|
-| Reading                   | `,?,R`                        | yes       |         |
-| Writing                   | `,?,W`                        | yes       |         |
-| Appending                 | `,?,A`                        | yes       | Warning, see below<sup>1</sup> |
-| Modifying                 | `,?,M`                        | yes       |         |
-| Types                     | `,S`/`,P`/`,U`/`,L`           | yes       | ignored on FAT32 |
-| Overwriting               | `@:`                          | yes       |         |
-| Magic channels 0/1        |                               | yes       |         |
-| Channel 15 command        | _command_`:`_args_...         | yes       |         |
-| Channel 15 status         | _code_`,`_string_`,`_a_`,`_b_ | yes       |         |
-| CMD partition syntax      | `0:`/`1:`/...                 | yes       |         |
-| CMD subdirectory syntax   | `//DIR/:`/`/DIR/:`            | yes       |         |
-| Directory listing         | `$`                           | yes       |         |
-| Dir with name filtering   | `$:FIL*`                      | yes       |         |
-| Dir with name and type filtering   | `$:*=P`/`$:*=D`/`$:*=A`       | yes       |         |
-| Dir with timestamps       | `$=T`                         | yes       | with ISO-8601 times |
-| Dir with time filtering   | `$=T<`/`$=T>`                 | not yet   |         |
-| Dir long listing          | `$=L`                         | yes       | shows human readable file size instead of blocks, time in ISO-8601 syntax, attribute byte, and exact file size in hexadecimal |
-| Partition listing         | `$=P`                         | yes       |         |
-| Partition filtering       | `$:NAME*=P`                   | no        |         |
-| Current Working Directory | `$=C`                         | yes       |         |
+| Feature                          | Syntax                        | Supported | Comment                                                                                                                       |
+|----------------------------------|-------------------------------|-----------|-------------------------------------------------------------------------------------------------------------------------------|
+| Reading                          | `,?,R`                        | yes       |                                                                                                                               |
+| Writing                          | `,?,W`                        | yes       |                                                                                                                               |
+| Appending                        | `,?,A`                        | yes       | Warning, see below<sup>1</sup>                                                                                                |
+| Modifying                        | `,?,M`                        | yes       |                                                                                                                               |
+| Types                            | `,S`/`,P`/`,U`/`,L`           | yes       | ignored on FAT32                                                                                                              |
+| Overwriting                      | `@:`                          | yes       |                                                                                                                               |
+| Magic channels 0/1               |                               | yes       |                                                                                                                               |
+| Channel 15 command               | _command_`:`_args_...         | yes       |                                                                                                                               |
+| Channel 15 status                | _code_`,`_string_`,`_a_`,`_b_ | yes       |                                                                                                                               |
+| CMD partition syntax             | `0:`/`1:`/...                 | yes       |                                                                                                                               |
+| CMD subdirectory syntax          | `//DIR/:`/`/DIR/:`            | yes       |                                                                                                                               |
+| Directory listing                | `$`                           | yes       |                                                                                                                               |
+| Dir with name filtering          | `$:FIL*`                      | yes       |                                                                                                                               |
+| Dir with name and type filtering | `$:*=P`/`$:*=D`/`$:*=A`       | yes       |                                                                                                                               |
+| Dir with timestamps              | `$=T`                         | yes       | with ISO-8601 times                                                                                                           |
+| Dir with time filtering          | `$=T<`/`$=T>`                 | not yet   |                                                                                                                               |
+| Dir long listing                 | `$=L`                         | yes       | shows human readable file size instead of blocks, time in ISO-8601 syntax, attribute byte, and exact file size in hexadecimal |
+| Partition listing                | `$=P`                         | yes       |                                                                                                                               |
+| Partition filtering              | `$:NAME*=P`                   | no        |                                                                                                                               |
+| Current Working Directory        | `$=C`                         | yes       |                                                                                                                               |
 
 * <sup>1</sup>: Warning: Risk of corrupting SD cards on older ROM versions, see [Appending to file](#appending-to-file)
 

--- a/X16 Reference - 13 - Working with CMDR-DOS.md
+++ b/X16 Reference - 13 - Working with CMDR-DOS.md
@@ -242,7 +242,7 @@ Or the core feature set, these are the supported functions:
 |---------------------------|-------------------------------|-----------|---------|
 | Reading                   | `,?,R`                        | yes       |         |
 | Writing                   | `,?,W`                        | yes       |         |
-| Appending                 | `,?,A`                        | yes       |         |
+| Appending                 | `,?,A`                        | yes       | Warning, see below<sup>1</sup> |
 | Modifying                 | `,?,M`                        | yes       |         |
 | Types                     | `,S`/`,P`/`,U`/`,L`           | yes       | ignored on FAT32 |
 | Overwriting               | `@:`                          | yes       |         |
@@ -260,6 +260,8 @@ Or the core feature set, these are the supported functions:
 | Partition listing         | `$=P`                         | yes       |         |
 | Partition filtering       | `$:NAME*=P`                   | no        |         |
 | Current Working Directory | `$=C`                         | yes       |         |
+
+* <sup>1</sup>: Warning: Risk of corrupting SD cards on older ROM versions, see [Appending to file](#appending-to-file)
 
 And this table shows which of the standard commands are supported:
 
@@ -396,6 +398,11 @@ DOS"$=C"
 0    "/"                DIR
 65535 BLOCKS FREE.
 ```
+### Appending to file
+
+To append data to an existing file, open the file with `,?,A` and write to it.
+
+**Warning:** Appending to an empty file using R48 or older, will corrupt the file system, due to a severe Kernal bug. The bug is fixed in [#369](https://github.com/X16Community/x16-rom/pull/369). Keep this in mind when releasing software which appends to files, as some users may have older ROM versions installed.
 
 ## License
 


### PR DESCRIPTION
Add warnings regarding appending to file
- CMDR-DOS: Describe the problem ([#369](https://github.com/X16Community/x16-rom/pull/369))
- Kernal: Add warning for function SETNAM (referring to CMDR-DOS)
- Basic: Add warning for function BSAVE (referring to CMDR-DOS)

@mooinglemur 
@Fulgen301 FYI, you had some opinions on this one