### PR TITLE
Fix 65C816 Emulation mode flag description

### DIFF
--- a/X16 Reference - Appendix F - 65C816 Processor.md
+++ b/X16 Reference - Appendix F - 65C816 Processor.md
@@ -78,7 +78,7 @@ The native mode flags are as follows:
   i = Interrupts Disabled  
   z = Zero  
   c = Carry  
-  e = Emulation Mode (0=65C02 mode, 1=65C816 mode)
+  e = Emulation mode (0=65C816 mode, 1=65C02 mode)
 
 In emulation mode, the **m** and **x** flags are always set to 1.
 


### PR DESCRIPTION
The description of the Emulation mode flag had the meanings the wrong way around.  Fix this.

[1] W65C816S Datasheet
    https://www.westerndesigncenter.com/wdc/documentation/w65c816s.pdf
    "2.8 Processor Status Register (P)
    ... illustrates the features of the Native (E=0) and Emulation (E=1)
    modes.
    ...
    Table 2-1 W65C816S Microprocessor Programming Model
    ...
    Emulation
    1=W65C02 Emulation Mode
    0=Native Mode
    "