### PR TITLE
Added `CHKOUT`. It seemed to have been missing, but is referred in mu…

### DIFF
--- a/X16 Reference - 05 - KERNAL.md
+++ b/X16 Reference - 05 - KERNAL.md
@@ -97,6 +97,7 @@ The 16 bit ABI generally follows the following conventions:
 | `CLALL` | `$FFE7` | ChIO | Close all channels | | A X | C64 |
 | [`CLOSE`](#function-name-close) | `$FFC3` | ChIO | Close a channel | A | A X Y P | C64 |
 | `CHKIN` | `$FFC6` | ChIO | Set channel for character input | X | A X | C64 |
+| `CHKOUT` | `$FFC9` | ChIO | Set channel for character output | X | A X | C64 |
 | [`clock_get_date_time`](#function-name-clock_get_date_time) | `$FF50` | Time | Get the date and time | none | r0 r1 r2 r3 A X Y P | X16
 | [`clock_set_date_time`](#function-name-clock_set_date_time) | `$FF4D` | Time | Set the date and time | r0 r1 r2 r3 | A X Y P | X16
 | `CHRIN` | `$FFCF` | ChIO | Alias for `BASIN` | | A X | C64 |


### PR DESCRIPTION
So, looked like `CHKOUT` was missing from the list of calls.. Maybe an oversight? It's in the [C64 Programmer's Reference](https://archive.org/details/c64-programmer-ref/page/n297/mode/2up), and I can confirm it actually _does_ exist in the Commander X16 Kernel.. [x16-rom/x16-edit/common.inc](https://github.com/X16Community/x16-rom/blob/95fb18aa2ad9f9f879976d9af8ed09c0b67f6e05/x16-edit/common.inc#L49)