### PR TITLE
Escape pairs of dollar signs

### DIFF
--- a/X16 Reference - 03 - Editor.md
+++ b/X16 Reference - 03 - Editor.md
@@ -139,11 +139,11 @@ If there are two meanings listed, the first indicates input (a keypress) and the
 **Notes:**
 
 * $01: SWAP COLORS swaps the foreground and background colors in text mode
-* $07/$09/$0A/$18/$1B: have been added for ASCII compatibility. *[$0A/$18/$1B do not have any effect on output. Outputs of $08/$09 have their traditional C64 effect]*
-* $80: VERBATIM MODE prints the next character (only!) as a glyph without interpretation. This is similar to quote mode, but also includes codes CR ($0D) and DEL ($14).
+* \$07/\$09/\$0A/\$18/\$1B: have been added for ASCII compatibility. *[\$0A/\$18/\$1B do not have any effect on output. Outputs of \$08/\$09 have their traditional C64 effect]*
+* \$80: VERBATIM MODE prints the next character (only!) as a glyph without interpretation. This is similar to quote mode, but also includes codes CR (\$0D) and DEL (\$14).
 * F9-F12: these codes match the C65 additions
 * $84: This code is generated when pressing SHIFT+END.
-* Additionally, the codes $04/$06/$0B/$0C are interpreted when printing in graphics mode using `GRAPH_put_char`.
+* Additionally, the codes \$04/\$06/\$0B/\$0C are interpreted when printing in graphics mode using `GRAPH_put_char`.
 
 <!-- For PDF formatting -->
 <div class="page-break"></div>
@@ -336,22 +336,22 @@ SAVE"AUTOBOOT.X16
 
 The tables for the active keyboard layout reside in banked RAM, at $A000 on bank 0:
 
-| Addresses   | Description |
-|-------------|-------------|
-| $A000-$A07F | Table 0     |
-| $A080-$A0FF | Table 1     |
-| $A100-$A17F | Table 2     |
-| $A180-$A1FF | Table 3     |
-| $A200-$A27F | Table 4     |
-| $A280-$A07F | Table 5     |
-| $A300-$A37F | Table 6     |
-| $A380-$A3FF | Table 7     |
-| $A400-$A47F | Table 8     |
-| $A480-$A4FF | Table 9     |
-| $A500-$A57F | Table 10    |
-| $A580-$A58F | big-endian bitfield:<br/>keynum codes for which Caps means Shift |
-| $A590-$A66F | dead key table |
-| $A670-$A67E | ASCIIZ identifier (e.g. "ABC/X16") |
+| Addresses     | Description |
+|---------------|-------------|
+| \$A000-\$A07F | Table 0     |
+| \$A080-\$A0FF | Table 1     |
+| \$A100-\$A17F | Table 2     |
+| \$A180-\$A1FF | Table 3     |
+| \$A200-\$A27F | Table 4     |
+| \$A280-\$A07F | Table 5     |
+| \$A300-\$A37F | Table 6     |
+| \$A380-\$A3FF | Table 7     |
+| \$A400-\$A47F | Table 8     |
+| \$A480-\$A4FF | Table 9     |
+| \$A500-\$A57F | Table 10    |
+| \$A580-\$A58F | big-endian bitfield:<br/>keynum codes for which Caps means Shift |
+| \$A590-\$A66F | dead key table |
+| \$A670-\$A67E | ASCIIZ identifier (e.g. "ABC/X16") |
 
 The first byte of each of the 11 tables is the table ID which contains the encoding and the combination of modifiers that this table is for.
 

--- a/X16 Reference - 04 - BASIC.md
+++ b/X16 Reference - 04 - BASIC.md
@@ -326,13 +326,13 @@ This command does not allow for automatic bank advancing, but you can achieve a 
 BSAVE "MYFILE.BIN",8,1,$A000,$C000
 ```
 
-The above example saves a region of memory from $A000 in bank 1 through and including $BFFF, stopping before $C000.
+The above example saves a region of memory from \$A000 in bank 1 through and including \$BFFF, stopping before \$C000.
 
 ```BASIC
 BSAVE "MYFILE.BIN,S,A",8,2,$A000,$B000
 ```
 
-The above example appends a region of memory from $A000 through and including $AFFF, stopping before $B000.  Running both of the above examples in succession will result in a file MYFILE.BIN 12KiB in size.
+The above example appends a region of memory from \$A000 through and including \$AFFF, stopping before \$B000.  Running both of the above examples in succession will result in a file MYFILE.BIN 12KiB in size.
 
 **Warning:** Appending to file involves a risk of corrupting the file system of the SD card! See [Appending to file](X16%20Reference%20-%2013%20-%20Working%20with%20CMDR-DOS.md#appending-to-file).
 
@@ -460,7 +460,7 @@ A more elaborate X16-Edit manual can be found [here](https://github.com/X16Commu
 
 **Action:** Plays back a null-terminated script from MEMORY into the BASIC editor. Among other uses, this can be used to "type" in a program from a plain text file.
 
-* If the `ram bank` argument is omitted and the address is in the range $A000-$BFFF, the RAM bank selected by the `BANK` command is used.
+* If the `ram bank` argument is omitted and the address is in the range \$A000-\$BFFF, the RAM bank selected by the `BANK` command is used.
 * The input can span multiple RAM banks. The input will stop once it reaches a null byte ($00) or if a BASIC error occurs.
 * The redirected input only applies to BASIC immediate mode. While programs are running, the EXEC handling is suspended.
 
@@ -1531,7 +1531,7 @@ The first three arguments are required, but the last one is optional.
 
 * `sprite idx` is a value between 0-127 inclusive.
 * `VRAM bank` is a value, `0` or `1`, which represents which of the two 64k regions of VRAM to select.
-* `VRAM address` is a 16-bit value, $0000-$FFFF, is the address within the VRAM bank to point the sprite to. The lowest 5 bits are ignored.
+* `VRAM address` is a 16-bit value, \$0000-\$FFFF, is the address within the VRAM bank to point the sprite to. The lowest 5 bits are ignored.
 * `color depth` selects either 4 or 8-bit color depth for the sprite. 0 = 4-bit, 1 = 8-bit.  This attribute can also be set by the `SPRITE` command.
 
 **EXAMPLE of SPRITE Statement:**
@@ -1677,8 +1677,8 @@ In the default text modes, this can be used to retrieve the character a specific
 
 In addition, VPEEK can reach add-on VERA cards with higher bank numbers.
 
-BANK 2-3 is for IO3 (VERA at $9F60-$9F7F)  
-BANK 4-5 is for IO4 (VERA at $9F80-$9F9F)  
+BANK 2-3 is for IO3 (VERA at \$9F60-\$9F7F)  
+BANK 4-5 is for IO4 (VERA at \$9F80-\$9F9F)  
 
 **EXAMPLE of VPEEK Function:**
 
@@ -1695,8 +1695,8 @@ PRINT VPEEK(1,$B000) : REM SCREEN CODE OF CHARACTER AT 0/0 ON SCREEN
 
 In addition, VPOKE can reach add-on VERA cards with higher bank numbers.
 
-BANK 2-3 is for IO3 (VERA at $9F60-$9F7F)  
-BANK 4-5 is for IO4 (VERA at $9F80-$9F9F)  
+BANK 2-3 is for IO3 (VERA at \$9F60-\$9F7F)  
+BANK 4-5 is for IO4 (VERA at \$9F80-\$9F9F)  
 
 **EXAMPLE of VPOKE Statement:**
 
@@ -1756,12 +1756,12 @@ In BASIC, the LOAD, SAVE and OPEN statements default to the last-used IEEE devic
 
 Like on the C64, BASIC keywords are tokenized.
 
-* The C64 BASIC V2 keywords occupy the range of $80 (`END`) to $CB (`GO`).
-* BASIC V3.5 also used $CE (`RGR`) to $FD (`WHILE`).
-* BASIC V7 introduced the $CE escape code for function tokens $CE-$02 (`POT`) to $CE-$0A (`POINTER`), and the $FE escape code for statement tokens $FE-$02 (`BANK`) to $FE-$38 (`SLOW`).
-* The unreleased BASIC V10 extended the escaped tokens up to $CE-$0D (`RPALETTE`) and $FE-$45 (`EDIT`).
+* The C64 BASIC V2 keywords occupy the range of \$80 (`END`) to \$CB (`GO`).
+* BASIC V3.5 also used \$CE (`RGR`) to \$FD (`WHILE`).
+* BASIC V7 introduced the \$CE escape code for function tokens \$CE-\$02 (`POT`) to \$CE-\$0A (`POINTER`), and the \$FE escape code for statement tokens \$FE-\$02 (`BANK`) to \$FE-\$38 (`SLOW`).
+* The unreleased BASIC V10 extended the escaped tokens up to \$CE-\$0D (`RPALETTE`) and \$FE-\$45 (`EDIT`).
 
-The X16 BASIC aims to be as compatible as possible with this encoding. Keywords added to X16 BASIC that also exist in other versions of BASIC match the token, and new keywords are encoded in the ranges $CE-$80+ and $FE-$80+.
+The X16 BASIC aims to be as compatible as possible with this encoding. Keywords added to X16 BASIC that also exist in other versions of BASIC match the token, and new keywords are encoded in the ranges \$CE-\$80+ and \$FE-\$80+.
 
 ## Auto-Boot
 

--- a/X16 Reference - 05 - KERNAL.md
+++ b/X16 Reference - 05 - KERNAL.md
@@ -23,14 +23,14 @@ The Commander X16 contains a version of KERNAL as its operating system in ROM. I
 
 ## KERNAL Version
 
-The KERNAL version can be read from location $FF80 in ROM. A value of $FF indicates a custom build. All other values encode the build number. Positive numbers are release versions ($02 = release version 2), two's complement negative numbers are prerelease versions ($FE = $100 - 2 = prerelease version 2).
+The KERNAL version can be read from location \$FF80 in ROM. A value of \$FF indicates a custom build. All other values encode the build number. Positive numbers are release versions (\$02 = release version 2), two's complement negative numbers are prerelease versions (\$FE = $100 - 2 = prerelease version 2).
 
 ## Compatibility Considerations
 
 For applications to remain compatible between different versions of the ROM, they can rely upon:
 
-* the KERNAL API calls at $FF81-$FFF3
-* the KERNAL vectors at $0314-$0333
+* the KERNAL API calls at \$FF81-\$FFF3
+* the KERNAL vectors at \$0314-\$0333
 
 The following features must not be relied upon:
 
@@ -67,7 +67,7 @@ The following C128 APIs have equivalent functionality on the X16 but are not com
 
 There are lots of new APIs. Please note that their addresses and their behavior is still preliminary and can change between revisions.
 
-Some new APIs use the "16 bit" ABI, which uses virtual 16 bit registers r0 through r15, which are located in zero page locations $02 through $21: r0 = r0L = $02, r0H = $03, r1 = r1L = $04 etc.
+Some new APIs use the "16 bit" ABI, which uses virtual 16 bit registers r0 through r15, which are located in zero page locations \$02 through \$21: r0 = r0L = \$02, r0H = \$03, r1 = r1L = \$04 etc.
 
 The 16 bit ABI generally follows the following conventions:
 
@@ -207,33 +207,33 @@ Some notes:
 
 ### KERNAL Vectors
 
-The KERNAL indirect vectors ($0314-$0333) are fully compatible with the C64:
+The KERNAL indirect vectors (\$0314-\$0333) are fully compatible with the C64:
 
-$0314-$0315: `CINV` – IRQ Interrupt Routine  
-$0316-$0317: `CBINV` – BRK Instruction Interrupt  
-$0318-$0319: `NMINV` – Non-Maskable Interrupt  
-$031A-$031B: `IOPEN` – Kernal OPEN Routine  
-$031C-$031D: `ICLOSE` – Kernal CLOSE Routine  
-$031E-$031F: `ICHKIN` – Kernal CHKIN Routine  
-$0320-$0321: `ICKOUT` – Kernal CKOUT Routine  
-$0322-$0323: `ICLRCH` – Kernal CLRCHN Routine  
-$0324-$0325: `IBASIN` – Kernal CHRIN Routine  
-$0326-$0327: `IBSOUT` – Kernal CHROUT Routine  
-$0328-$0329: `ISTOP` – Kernal STOP Routine  
-$032A-$032B: `IGETIN` – Kernal GETIN Routine  
-$032C-$032D: `ICLALL` – Kernal CLALL Routine  
-$0330-$0331: `ILOAD` – Kernal LOAD Routine  
-$0332-$0333: `ISAVE` – Kernal SAVE Routine  
+\$0314-\$0315: `CINV` – IRQ Interrupt Routine  
+\$0316-\$0317: `CBINV` – BRK Instruction Interrupt  
+\$0318-\$0319: `NMINV` – Non-Maskable Interrupt  
+\$031A-\$031B: `IOPEN` – Kernal OPEN Routine  
+\$031C-\$031D: `ICLOSE` – Kernal CLOSE Routine  
+\$031E-\$031F: `ICHKIN` – Kernal CHKIN Routine  
+\$0320-\$0321: `ICKOUT` – Kernal CKOUT Routine  
+\$0322-\$0323: `ICLRCH` – Kernal CLRCHN Routine  
+\$0324-\$0325: `IBASIN` – Kernal CHRIN Routine  
+\$0326-\$0327: `IBSOUT` – Kernal CHROUT Routine  
+\$0328-\$0329: `ISTOP` – Kernal STOP Routine  
+\$032A-\$032B: `IGETIN` – Kernal GETIN Routine  
+\$032C-\$032D: `ICLALL` – Kernal CLALL Routine  
+\$0330-\$0331: `ILOAD` – Kernal LOAD Routine  
+\$0332-\$0333: `ISAVE` – Kernal SAVE Routine  
 
 Additional KERNAL indirect vectors have been added as part of the KERNAL's 65C816 support
 
-$0334-$0335: `IECOP` - COP Instruction Interrupt Routine (emulation mode)  
-$0336-$0337: `IEABORT` - ABORT Routine (emulation mode)  
-$0338-$0339: `INIRQ` - IRQ Interrupt Routine (native mode)  
-$033A-$033B: `INBRK` - BRK Instruction Interrupt Routine (native mode)  
-$033C-$033D: `INNMI` - Non-Maskable Interrupt Routine (native mode)  
-$033E-$033F: `INCOP` - COP Instruction Interrupt Routine (native mode)  
-$0340-$0341: `INABORT` - ABORT Routine (native mode)  
+\$0334-\$0335: `IECOP` - COP Instruction Interrupt Routine (emulation mode)  
+\$0336-\$0337: `IEABORT` - ABORT Routine (emulation mode)  
+\$0338-\$0339: `INIRQ` - IRQ Interrupt Routine (native mode)  
+\$033A-\$033B: `INBRK` - BRK Instruction Interrupt Routine (native mode)  
+\$033C-\$033D: `INNMI` - Non-Maskable Interrupt Routine (native mode)  
+\$033E-\$033F: `INCOP` - COP Instruction Interrupt Routine (native mode)  
+\$0340-\$0341: `INABORT` - ABORT Routine (native mode)  
 
 #### Handling NMI
 
@@ -259,8 +259,8 @@ values will need to be popped before returning from the NMI:
 
 The X16 adds two new functions for dealing with the Commodore Peripheral Bus ("IEEE"):
 
-$FEB1: `MCIOUT` - write multiple bytes to peripheral bus
-$FF44: `MACPTR` - read multiple bytes from peripheral bus
+\$FEB1: `MCIOUT` - write multiple bytes to peripheral bus
+\$FF44: `MACPTR` - read multiple bytes from peripheral bus
 
 ---
 
@@ -534,13 +534,13 @@ To append to a file, add `,?,A` to the filename. See [Appending to file](X16%20R
 
 ### Memory
 
-$FEE4: `memory_fill` - fill memory region with a byte value  
-$FEE7: `memory_copy` - copy memory region  
-$FEEA: `memory_crc` - calculate CRC16 of memory region  
-$FEED: `memory_decompress` - decompress LZSA2 block  
-$FF74: `fetch` - read a byte from any RAM or ROM bank  
-$FF77: `stash` - write a byte to any RAM bank
-$FF99: `MEMTOP` - get number of banks and address of end of usable RAM
+\$FEE4: `memory_fill` - fill memory region with a byte value  
+\$FEE7: `memory_copy` - copy memory region  
+\$FEEA: `memory_crc` - calculate CRC16 of memory region  
+\$FEED: `memory_decompress` - decompress LZSA2 block  
+\$FF74: `fetch` - read a byte from any RAM or ROM bank  
+\$FF77: `stash` - write a byte to any RAM bank
+\$FF99: `MEMTOP` - get number of banks and address of end of usable RAM
 
 <!---
 *** undocumented - we might remove it
@@ -556,7 +556,7 @@ Call address: $FEE4
 
 **Description:** This function fills the memory region specified by an address (r0) and a size in bytes (r1) with the constant byte value passed in .A. r0 and .A are preserved, r1 is destroyed.
 
-If the target address is in the $9F00-$9FFF range, all bytes will be written to the same address (r0), i.e. the address will not be incremented. This is useful for filling VERA memory ($9F23 or $9F24), for example.
+If the target address is in the \$9F00-\$9FFF range, all bytes will be written to the same address (r0), i.e. the address will not be incremented. This is useful for filling VERA memory (\$9F23 or \$9F24), for example.
 
 ---
 
@@ -568,7 +568,7 @@ Call address: $FEE7
 
 **Description:** This function copies one memory region specified by an address (r0) and a size in bytes (r2) to a different region specified by its start address (r1). The two regions may overlap. r0 and r1 are preserved, r2 is destroyed.
 
-Like with `memory_fill`, source and destination addresses in the $9F00-$9FFF range will not be incremented during the copy. This allows, for instance, uploading data from RAM to VERA (destination of $9F23 or $9F24), downloading data from VERA (source $9F23 or $9F24) or copying data inside VERA (source $9F23, destination $9F24). This functionality can also be used to upload, download or transfer data with other I/O devices that have an 8 bit data port.
+Like with `memory_fill`, source and destination addresses in the \$9F00-\$9FFF range will not be incremented during the copy. This allows, for instance, uploading data from RAM to VERA (destination of \$9F23 or \$9F24), downloading data from VERA (source \$9F23 or \$9F24) or copying data inside VERA (source \$9F23, destination \$9F24). This functionality can also be used to upload, download or transfer data with other I/O devices that have an 8 bit data port.
 
 ---
 
@@ -580,7 +580,7 @@ Call address: $FEEA
 
 **Description:** This function calculates the CRC16 checksum ([CRC-16/IBM-3740](https://www.crccalc.com/?crc=01%2002%2003%2004&method=CRC-16/IBM-3740&datatype=hex&outtype=hex)) of the memory region specified by an address (r0) and a size in bytes (r1). The result is returned in r2. r0 is preserved, r1 is destroyed.
 
-Like `memory_fill`, this function does not increment the address if it is in the range of $9F00-$9FFF, which allows checksumming VERA memory or data streamed from any other I/O device.
+Like `memory_fill`, this function does not increment the address if it is in the range of \$9F00-\$9FFF, which allows checksumming VERA memory or data streamed from any other I/O device.
 
 Note: ROM R48 and older contains the following bug: If the size of the data is not a multiple of 256, the remainder of the data is processed in the wrong byte order. This bug was fixed in [#382](https://github.com/X16Community/x16-rom/pull/382). Thus, if your data is not a multiple of 256, you will get different CRC depending of ROM version.
 
@@ -594,7 +594,7 @@ Call address: $FEED
 
 **Description:** This function decompresses an LZSA2-compressed data block from the location passed in r0 and outputs the decompressed data at the location passed in r1. After the call, r1 will be updated with the location of the last output byte plus one.
 
-If the target address is in the $9F00-$9FFF range, all bytes will be written to the same address (r0), i.e. the address will not be incremented. This is useful for decompressing directly into VERA memory ($9F23 or $9F24), for example. Note that decompressing _from_ I/O is not supported.
+If the target address is in the \$9F00-\$9FFF range, all bytes will be written to the same address (r0), i.e. the address will not be incremented. This is useful for decompressing directly into VERA memory (\$9F23 or \$9F24), for example. Note that decompressing _from_ I/O is not supported.
 
 **Notes**:
 
@@ -663,10 +663,10 @@ the system in A. For example:
 ```
 
 If the system has 512k of banked RAM, zp_NUM_BANKS
-will contain $40 (64). For 1024k, $80; for 1536k, $C0.
-For 2048k, the result will be $00 (which can be thought
-of as $100, or 256). It is possible to have other
-values (e.g. $42), such as if the system has bad
+will contain \$40 (64). For 1024k, \$80; for 1536k, \$C0.
+For 2048k, the result will be \$00 (which can be thought
+of as \$100, or 256). It is possible to have other
+values (e.g. \$42), such as if the system has bad
 banked RAM.
 
 **Setting the top of BASIC RAM**
@@ -683,9 +683,9 @@ language routine at the top of BASIC RAM, just below the I/O space:
 
 Analysis: 
 
-The SYS command uses memory locations $30C-$30F to pre-load the CPU registers,
+The SYS command uses memory locations \$30C-\$30F to pre-load the CPU registers,
 it then dumps the registers back to these locations after the SYS call is
-complete. $30D is the X register, $30E is .Y, and $30F is the flags. The Carry
+complete. \$30D is the X register, \$30E is .Y, and \$30F is the flags. The Carry
 flag is bit 0, so setting $30F to 1 before calling MEMTOP indicates that this is
 a _read_ of the values. 
 
@@ -699,18 +699,18 @@ a _read_ of the values.
    variables, you should _probably_ do this at the top of your program.
 
 The address entered is actually the first byte of free space _after_
-your BASIC program space, so if you set MEMTOP to $9C00, then you can start your
-assembly program at $9C00 with `* = $9C00` or `org $9c00`.
+your BASIC program space, so if you set MEMTOP to \$9C00, then you can start your
+assembly program at \$9C00 with `* = $9C00` or `org $9c00`.
 
-To reserve 256 bytes, set X to $9E. To reserve 1KB, set X to $9C. To return to
-the default values, set Y=$9F and X=0.
+To reserve 256 bytes, set X to \$9E. To reserve 1KB, set X to \$9C. To return to
+the default values, set Y=\$9F and X=0.
 
 ---
 
 ### Clock
 
-$FF4D: `clock_set_date_time` - set date and time  
-$FF50: `clock_get_date_time` - get date and time  
+\$FF4D: `clock_set_date_time` - set date and time  
+\$FF50: `clock_get_date_time` - get date and time  
 
 ---
 
@@ -781,10 +781,10 @@ sty STARTTIME+2  ; most significant byte
 
 ### Keyboard
 
-$FEBD: `kbdbuf_peek` - get first char in keyboard queue and queue length  
-$FEC0: `kbdbuf_get_modifiers` - get currently pressed modifiers  
-$FEC3: `kbdbuf_put` - append a char to the keyboard queue  
-$FED2: `keymap` - set or get the current keyboard layout
+\$FEBD: `kbdbuf_peek` - get first char in keyboard queue and queue length  
+\$FEC0: `kbdbuf_get_modifiers` - get currently pressed modifiers  
+\$FEC3: `kbdbuf_put` - append a char to the keyboard queue  
+\$FED2: `keymap` - set or get the current keyboard layout
 
 ---
 
@@ -872,9 +872,9 @@ Unless the KERNAL IRQ handler is being bypassed or supplemented, it is not norma
 
 ### Mouse
 
-$FF68: `mouse_config` - configure mouse pointer  
-$FF71: `mouse_scan` - query mouse  
-$FF6B: `mouse_get` - get state of mouse
+\$FF68: `mouse_config` - configure mouse pointer  
+\$FF71: `mouse_scan` - query mouse  
+\$FF6B: `mouse_get` - get state of mouse
 
 ---
 
@@ -960,8 +960,8 @@ BNE BUTTON_PRESSED
 
 ### Joystick
 
-$FF53: `joystick_scan` - query joysticks  
-$FF56: `joystick_get` - get state of one joystick
+\$FF53: `joystick_scan` - query joysticks  
+\$FF56: `joystick_get` - get state of one joystick
 
 ---
 
@@ -1046,10 +1046,10 @@ If the default interrupt handler is disabled or replaced:
 
 ### I2C
 
-$FEB4: `i2c_batch_read` - read multiple bytes from an I2C device  
-$FEB7: `i2c_batch_write` - write multiple bytes to an I2C device  
-$FEC6: `i2c_read_byte` - read a byte from an I2C device  
-$FEC9: `i2c_write_byte` - write a byte to an I2C device
+\$FEB4: `i2c_batch_read` - read multiple bytes from an I2C device  
+\$FEB7: `i2c_batch_write` - write multiple bytes to an I2C device  
+\$FEC6: `i2c_read_byte` - read a byte from an I2C device  
+\$FEC9: `i2c_write_byte` - write a byte to an I2C device
 
 ---
 
@@ -1176,8 +1176,8 @@ JSR $FEC9 ; reset the computer
 
 ### Sprites
 
-$FEF0: `sprite_set_image` - set the image of a sprite  
-$FEF3: `sprite_set_position` - set the position of a sprite
+\$FEF0: `sprite_set_image` - set the image of a sprite  
+\$FEF3: `sprite_set_position` - set the position of a sprite
 
 ---
 
@@ -1381,18 +1381,18 @@ Purpose: Copy horizontally consecutive pixels to a different position
 
 The high-level graphics API exposes a set of standard functions. It allows applications to easily perform some common high-level actions like drawing lines, rectangles and images, as well as moving parts of the screen. All commands are completely implemented on top of the framebuffer API, that is, they will continue working after replacing the framebuffer driver with one that supports a different resolution, color depth or even graphics device.
 
-$FF20: `GRAPH_init` - initialize graphics  
-$FF23: `GRAPH_clear` - clear screen  
-$FF26: `GRAPH_set_window` - set clipping region  
-$FF29: `GRAPH_set_colors` - set stroke, fill and background colors  
-$FF2C: `GRAPH_draw_line` - draw a line  
-$FF2F: `GRAPH_draw_rect` - draw a rectangle (optionally filled)  
-$FF32: `GRAPH_move_rect` - move pixels  
-$FF35: `GRAPH_draw_oval` - draw an oval or circle  
-$FF38: `GRAPH_draw_image` - draw a rectangular image  
-$FF3B: `GRAPH_set_font` - set the current font  
-$FF3E: `GRAPH_get_char_size` - get size and baseline of a character  
-$FF41: `GRAPH_put_char` - print a character
+\$FF20: `GRAPH_init` - initialize graphics  
+\$FF23: `GRAPH_clear` - clear screen  
+\$FF26: `GRAPH_set_window` - set clipping region  
+\$FF29: `GRAPH_set_colors` - set stroke, fill and background colors  
+\$FF2C: `GRAPH_draw_line` - draw a line  
+\$FF2F: `GRAPH_draw_rect` - draw a rectangle (optionally filled)  
+\$FF32: `GRAPH_move_rect` - move pixels  
+\$FF35: `GRAPH_draw_oval` - draw an oval or circle  
+\$FF38: `GRAPH_draw_image` - draw a rectangular image  
+\$FF3B: `GRAPH_set_font` - set the current font  
+\$FF3E: `GRAPH_get_char_size` - get size and baseline of a character  
+\$FF41: `GRAPH_put_char` - print a character
 
 ---
 
@@ -1519,32 +1519,32 @@ Purpose: Print a character onto the graphics screen
 * $0A: LF
 * $0B: ATTRIBUTES: ITALICS
 * $0C: ATTRIBUTES: OUTLINE
-* $0D/$8D: REGULAR/SHIFTED RETURN
-* $11/$91: CURSOR: DOWN/UP
+* \$0D/\$8D: REGULAR/SHIFTED RETURN
+* \$11/\$91: CURSOR: DOWN/UP
 * $12: ATTRIBUTES: REVERSE
-* $13/$93: HOME/CLEAR
+* \$13/\$93: HOME/CLEAR
 * $14 DEL
 * $92: ATTRIBUTES: CLEAR ALL
 * all color codes
 
 Notes:
 
-* CR ($0D) SHIFT+CR ($8D) and LF ($0A) all set the cursor to the beginning of the next line. The only difference is that CR and SHIFT+CR reset the attributes, and LF does not.
-* BACKSPACE ($08) and DEL ($14) move the cursor to the beginning of the previous character but does not actually clear it. Multiple consecutive BACKSPACE/DEL characters are not supported.
+* CR (\$0D) SHIFT+CR (\$8D) and LF (\$0A) all set the cursor to the beginning of the next line. The only difference is that CR and SHIFT+CR reset the attributes, and LF does not.
+* BACKSPACE (\$08) and DEL (\$14) move the cursor to the beginning of the previous character but does not actually clear it. Multiple consecutive BACKSPACE/DEL characters are not supported.
 * There is no way to individually disable attributes (underlined, bold, reversed, italics, outline). The only way to disable them is to reset the attributes using code $92, which switches to plain text.
 * All 16 PETSCII color codes are supported. Code $01 to swap the colors will swap the stroke and fill colors.
 * The stroke color is used to draw the characters, and the underline is drawn using the fill color. In reverse text mode, the text background is filled with the fill color.
-* *[BELL ($07), TAB ($09) and SHIFT+TAB ($18) are not yet implemented.]*
+* *[BELL (\$07), TAB (\$09) and SHIFT+TAB (\$18) are not yet implemented.]*
 
 ---
 
 ### Console
 
-$FEDB: `console_init` - initialize console mode  
-$FEDE: `console_put_char` - print character to console  
-$FED8: `console_put_image` - draw image as if it was a character  
-$FEE1: `console_get_char` - get character from console  
-$FED5: `console_set_paging_message` - set paging message or disable paging
+\$FEDB: `console_init` - initialize console mode  
+\$FEDE: `console_put_char` - print character to console  
+\$FED8: `console_put_image` - draw image as if it was a character  
+\$FEE1: `console_get_char` - get character from console  
+\$FED5: `console_set_paging_message` - set paging message or disable paging
 
 The console is a screen mode that allows text output and input in proportional fonts that support the usual styles. It is useful for rich text-based interfaces.
 
@@ -1613,13 +1613,13 @@ Call address: $FED5
 
 ### Other
 
-$FF47: `enter_basic` - enter BASIC  
-$FECF: `entropy_get` - get 24 random bits  
-$FEAB: `extapi` - extended API  
-$FECC: `monitor` - enter machine language monitor  
-$FF5F: `screen_mode` - get/set screen mode  
-$FF62: `screen_set_charset` - activate 8x8 text mode charset  
-$FFED: `SCREEN` - get the text resolution  
+\$FF47: `enter_basic` - enter BASIC  
+\$FECF: `entropy_get` - get 24 random bits  
+\$FEAB: `extapi` - extended API  
+\$FECC: `monitor` - enter machine language monitor  
+\$FF5F: `screen_mode` - get/set screen mode  
+\$FF62: `screen_set_charset` - activate 8x8 text mode charset  
+\$FFED: `SCREEN` - get the text resolution  
 
 #### Function Name: enter_basic
 
@@ -2703,15 +2703,15 @@ Registers affected: .A .X .Y .P .SP
 
 #### 65C816 extapi16 Function Name: stack_enter_kernal_stack
 
-Purpose: Point the SP to the previously-saved $01xx stack, preserving the current one  
+Purpose: Point the SP to the previously-saved \$01xx stack, preserving the current one  
 Minimum ROM version: R47  
-Call address: $FEA8, .C=3  
+Call address: \$FEA8, .C=3  
 Communication registers: none  
 Preparatory routines: `stack_push`  
 Error returns: none  
 Registers affected: .A .X .Y .P .SP  
 
-**Description:** This function requests that the KERNAL temporarily bring the $01xx stack into effect during use a different stack. This is useful for applications which have moved the SP away from $01xx but need to call the KERNAL API or legacy code.
+**Description:** This function requests that the KERNAL temporarily bring the \$01xx stack into effect during use a different stack. This is useful for applications which have moved the SP away from \$01xx but need to call the KERNAL API or legacy code.
 
 **How to Use:**
 

--- a/X16 Reference - 06 - Math Library.md
+++ b/X16 Reference - 06 - Math Library.md
@@ -132,7 +132,7 @@ To perform a floating point calculation, follow the following pattern:
 1. the result is in FACC, move it into MEM somewhere or convert it to another type or string.
 
 An example program that calculates and prints the distance an object has fallen over a certain period
-using the formula  $d = \dfrac{1}{2} g {t}^{2}$
+using the formula $d = \dfrac{1}{2} g {t}^{2}$
 
 ```ASM
 ; calculate how far an object has fallen:  d = 1/2 * g * t^2.

--- a/X16 Reference - 08 - Memory Map.md
+++ b/X16 Reference - 08 - Memory Map.md
@@ -9,10 +9,10 @@ This is an overview of the X16 memory map:
 
 |Addresses  |Description                                                                             |
 |-----------|----------------------------------------------------------------------------------------|
-|$0000-$9EFF|Fixed RAM (40 KB minus 256 bytes)                                                       |
-|$9F00-$9FFF|I/O Area (256 bytes)                                                                    |
-|$A000-$BFFF|Banked RAM (8 KB window into one of 256 banks for a total of 2 MB)                      |
-|$C000-$FFFF|Banked System ROM and Cartridge ROM/RAM (16 KB window into one of 256 banks, see below) |
+|\$0000-\$9EFF|Fixed RAM (40 KB minus 256 bytes)                                                       |
+|\$9F00-\$9FFF|I/O Area (256 bytes)                                                                    |
+|\$A000-\$BFFF|Banked RAM (8 KB window into one of 256 banks for a total of 2 MB)                      |
+|\$C000-\$FFFF|Banked System ROM and Cartridge ROM/RAM (16 KB window into one of 256 banks, see below) |
 
 ## Banked Memory
 
@@ -62,27 +62,27 @@ for ideas on how this may be used. This provides up to 3.5MB of additional RAM o
 
 This is the allocation of fixed RAM in the KERNAL/BASIC environment.
 
-|Addresses  |Description                                                     |
-|-----------|----------------------------------------------------------------|
-|$0000-$00FF|Zero page                                                       |
-|$0100-$01FF|CPU stack                                                       |
-|$0200-$03FF|KERNAL and BASIC variables, vectors                             |
-|$0400-$07FF|Available for machine code programs or custom data storage      |
-|$0800-$9EFF|BASIC program/variables; available to the user                  |
+|Addresses   |Description                                                      |
+|------------|-----------------------------------------------------------------|
+|\$0000-\$00FF|Zero page                                                       |
+|\$0100-\$01FF|CPU stack                                                       |
+|\$0200-\$03FF|KERNAL and BASIC variables, vectors                             |
+|\$0400-\$07FF|Available for machine code programs or custom data storage      |
+|\$0800-\$9EFF|BASIC program/variables; available to the user                  |
 
 The `$0400-$07FF` can be seen as the equivalent of `$C000-$CFFF` on a C64. A typical use would be for helper machine code called by BASIC.
 
 ### Zero Page
 
-|Addresses  |Description                            |
-|-----------|---------------------------------------|
-|$0000-$0001|Banking registers                      |
-|$0002-$0021|16 bit registers r0-r15 for KERNAL API |
-|$0022-$007F|Available to the user                  |
-|$0080-$009C|Used by KERNAL and DOS                 |
-|$009D-$00A8|Reserved for DOS/BASIC                 |
-|$00A9-$00D3|Used by the Math library (and BASIC)   |
-|$00D4-$00FF|Used by BASIC                          |
+|Addresses   |Description                             |
+|------------|----------------------------------------|
+|\$0000-\$0001|Banking registers                      |
+|\$0002-\$0021|16 bit registers r0-r15 for KERNAL API |
+|\$0022-\$007F|Available to the user                  |
+|\$0080-\$009C|Used by KERNAL and DOS                 |
+|\$009D-\$00A8|Reserved for DOS/BASIC                 |
+|\$00A9-\$00D3|Used by the Math library (and BASIC)   |
+|\$00D4-\$00FF|Used by BASIC                          |
 
 Machine code applications are free to reuse the BASIC area, and if they don't use the Math library, also that area.
 
@@ -101,10 +101,10 @@ During startup, the KERNAL activates RAM bank 1 as the default for the user.
 
 ### Bank 0
 
-|Addresses  |Description                            |
-|-----------|---------------------------------------|
-|$A000-$BEFF| System Reserved                       |
-|$BF00-$BFFF| Parameter passing space               |
+|Addresses   |Description                             |
+|------------|----------------------------------------|
+|\$A000-\$BEFF| System Reserved                       |
+|\$BF00-\$BFFF| Parameter passing space               |
 
 You can use the space at $0:BF00-0:$BFFF to pass parameters between programs.
 This space is initalized to zeroes, so you may use it however you wish.
@@ -125,16 +125,16 @@ This is the memory map of the I/O Area:
 
 |Addresses    |Description                          |Speed|
 |-------------|-------------------------------------|-----|
-|$9F00-$9F0F|VIA I/O controller #1                |8 MHz|
-|$9F10-$9F1F|VIA I/O controller #2                |8 MHz|
-|$9F20-$9F3F|VERA video controller                |8 MHz|
-|$9F40-$9F41|YM2151 audio controller              |2 MHz|
-|$9F42-$9F5F|Unavailable                          | --- |
-|$9F60-$9F7F|Expansion Card Memory Mapped IO3     |8 MHz|
-|$9F80-$9F9F|Expansion Card Memory Mapped IO4     |8 MHz|
-|$9FA0-$9FBF|Expansion Card Memory Mapped IO5     |2 MHz|
-|$9FC0-$9FDF|Expansion Card Memory Mapped IO6     |2 MHz|
-|$9FE0-$9FFF|Cartidge/Expansion Memory Mapped IO7 |2 MHz|
+|\$9F00-\$9F0F|VIA I/O controller #1                |8 MHz|
+|\$9F10-\$9F1F|VIA I/O controller #2                |8 MHz|
+|\$9F20-\$9F3F|VERA video controller                |8 MHz|
+|\$9F40-\$9F41|YM2151 audio controller              |2 MHz|
+|\$9F42-\$9F5F|Unavailable                          | --- |
+|\$9F60-\$9F7F|Expansion Card Memory Mapped IO3     |8 MHz|
+|\$9F80-\$9F9F|Expansion Card Memory Mapped IO4     |8 MHz|
+|\$9FA0-\$9FBF|Expansion Card Memory Mapped IO5     |2 MHz|
+|\$9FC0-\$9FDF|Expansion Card Memory Mapped IO6     |2 MHz|
+|\$9FE0-\$9FFF|Cartidge/Expansion Memory Mapped IO7 |2 MHz|
 
 ### Expansion Cards & Cartridges
 

--- a/X16 Reference - 09 - VERA Programmer's Reference.md
+++ b/X16 Reference - 09 - VERA Programmer's Reference.md
@@ -32,7 +32,7 @@ The VERA consists of:
 
 # Registers
 
-## $9F20-$9F28
+## \$9F20-\$9F28
 
 <table>
 	<tr>
@@ -115,7 +115,7 @@ The VERA consists of:
 	</tr>
 </table>
 
-## $9F29-$9F2C
+## \$9F29-\$9F2C
 
 <details open>
 	<summary>DCSEL=0</summary>
@@ -480,7 +480,7 @@ The VERA consists of:
 	</table>
 </details>
 
-## $9F2D-$9F3F
+## \$9F2D-\$9F3F
 
 <table>
 	<tr>
@@ -620,34 +620,34 @@ The VERA consists of:
 
 ## VRAM address space layout
 
-| Address range     | Description                |
-| ----------------- | -------------------------- |
-| $0:0000 - $1:F9BF | Video RAM                  |
-| $1:F9C0 - $1:F9FF | PSG registers              |
-| $1:FA00 - $1:FBFF | Palette                    |
-| $1:FC00 - $1:FFFF | Sprite attributes          |
+| Address range      | Description                 |
+| ------------------ | --------------------------- |
+| \$0:0000 - \$1:F9BF | Video RAM                  |
+| \$1:F9C0 - \$1:F9FF | PSG registers              |
+| \$1:FA00 - \$1:FBFF | Palette                    |
+| \$1:FC00 - \$1:FFFF | Sprite attributes          |
 
 The X16 KERNAL uses the following video memory layout:
 
-| Addresses       | Description                                               |
-|-----------------|-----------------------------------------------------------|
-| $0:0000-$1:2BFF | 320x240@256c Bitmap                                       |
-| $1:2C00-$1:2FFF | *unused* (1024 bytes)                                     |
-| $1:3000-$1:AFFF | Sprite Image Data (up to $1000 per sprite at 64x64 8-bit) |
-| $1:B000-$1:EBFF | Text Mode                                                 |
-| $1:EC00-$1:EFFF | *unused* (1024 bytes)                                     |
-| $1:F000-$1:F7FF | Charset                                                   |
-| $1:F800-$1:F9BF | *unused* (448 bytes)                                     |
-| $1:F9C0-$1:F9FF | VERA PSG Registers (16 x 4 bytes)                         |
-| $1:FA00-$1:FBFF | VERA Color Palette (256 x 2 bytes)                        |
-| $1:FC00-$1:FFFF | VERA Sprite Attributes (128 x 8 bytes)                    |
+| Addresses        | Description                                                |
+|------------------|------------------------------------------------------------|
+| \$0:0000-\$1:2BFF | 320x240@256c Bitmap                                       |
+| \$1:2C00-\$1:2FFF | *unused* (1024 bytes)                                     |
+| \$1:3000-\$1:AFFF | Sprite Image Data (up to $1000 per sprite at 64x64 8-bit) |
+| \$1:B000-\$1:EBFF | Text Mode                                                 |
+| \$1:EC00-\$1:EFFF | *unused* (1024 bytes)                                     |
+| \$1:F000-\$1:F7FF | Charset                                                   |
+| \$1:F800-\$1:F9BF | *unused* (448 bytes)                                      |
+| \$1:F9C0-\$1:F9FF | VERA PSG Registers (16 x 4 bytes)                         |
+| \$1:FA00-\$1:FBFF | VERA Color Palette (256 x 2 bytes)                        |
+| \$1:FC00-\$1:FFFF | VERA Sprite Attributes (128 x 8 bytes)                    |
 
-**This memory map is not fixed**: All of the address space between $0:0000 and $1:F9BF is available for any use in your programs, if you do not need text displayed by KERNAL or BASIC. This includes allocating multiple text or graphic buffers, or simply re-arranging the buffers to allow for
+**This memory map is not fixed**: All of the address space between \$0:0000 and \$1:F9BF is available for any use in your programs, if you do not need text displayed by KERNAL or BASIC. This includes allocating multiple text or graphic buffers, or simply re-arranging the buffers to allow for
 certain tile set layouts. Just be aware that once you move things around, you'll have to fully manage your bitmaps, tiles, and text/tile buffers. 
 
 To restore the standard text mode, call `CINT` ($FF81). This will reset the screen to the default screen mode. If you have configured custom settings in your NVRAM, these will be used.
 
-Also, the registers in $1:F9C0-$1:FFFF are actually write-only. However, they share the same address as part of the video RAM. Be aware that when you read back the register data, you are actually reading the last value sent by the host system, which is not necessarily the value in the register.
+Also, the registers in \$1:F9C0-\$1:FFFF are actually write-only. However, they share the same address as part of the video RAM. Be aware that when you read back the register data, you are actually reading the last value sent by the host system, which is not necessarily the value in the register.
 To make sure this data is filled with known values, we recommend fully initializng the registers before use. Normally, the X16 KERNAL handles this for you, but if you are writing a cartridge program, using the system with a custom ROM, or even running VERA on another computer, then you'll 
 need to make sure this block gets initialized to known values. 
 

--- a/X16 Reference - 10 - VERA FX Reference.md
+++ b/X16 Reference - 10 - VERA FX Reference.md
@@ -19,7 +19,7 @@ In other words: the CPU is still the orchestrator of all that is done, but it is
 
 ### DCSEL
 
-VERA is mapped as 32 8-bit registers in the memory space of the Commander X16, starting at address $9F20 and ending at $9F3F. Many of these are (fully) used, but some bits remain unused. The DCSEL bits in register $9F25 (also called CTRL) has been extended to 6-bits to allow for the 4 registers $9F29-$9F2C to have additional meanings.
+VERA is mapped as 32 8-bit registers in the memory space of the Commander X16, starting at address \$9F20 and ending at \$9F3F. Many of these are (fully) used, but some bits remain unused. The DCSEL bits in register \$9F25 (also called CTRL) has been extended to 6-bits to allow for the 4 registers \$9F29-\$9F2C to have additional meanings.
 
 <table>
 	<tr>

--- a/X16 Reference - 11 - Sound Programming.md
+++ b/X16 Reference - 11 - Sound Programming.md
@@ -758,7 +758,7 @@ The Operator Control parameters are mapped to channels/operators as follows: Reg
 
 **DT1** (Detune 1 - fine detune)
 
-Registers $40-$5F, Bits 4-6
+Registers \$40-\$5F, Bits 4-6
 
 Detunes the operator from the channel's main pitch. Values 0 and 4=no detuning.
 Values 1-3=detune up, 5-7 = detune down.<br/>
@@ -766,50 +766,50 @@ The amount of detuning varies with pitch. It decreases as the channel's pitch in
 
 **MUL** (Frequency Multiplier)
 
-Registers $40-$5F, Bits 0-3
+Registers \$40-\$5F, Bits 0-3
 
 If MUL=0, it multiplies the operator's frequency by 0.5<br/>
 Otherwise, the frequency is multiplied by the value in MUL (1,2,3...etc)
 
 **TL** (Total Level - attenuation)
 
-Registers $60-$7F, Bits 0-6
+Registers \$60-\$7F, Bits 0-6
 
 This is essentially "volume control" - It is an attenuation value, so $00 = maximum level and $7F is minimum level. On output operators, this is the volume output by that operator. On modulating operators, this affects the amount of modulation done to other operators.
 
 **KS** (Key Scaling)
 
-Registers $80-$9F, Bits 6-7
+Registers \$80-\$9F, Bits 6-7
 
 Controls the speed of the ADSR progression. The KS value sets four different levels of scaling. Key scaling increases along with the pitch set in KC. 0=min, 3=max
 
 **AR** (Attack Rate)
 
-Registers $80-$9F, Bits 0-4
+Registers \$80-\$9F, Bits 0-4
 
 Sets the attack rate of the ADSR envelope. 0=slowest, $1F=fastest
 
 **AMS-Enable** (Amplitude Modulation Sensitivity Enable)
 
-Registers $A0-$BF, Bit 7
+Registers \$A0-\$BF, Bit 7
 
 If set, the operator's output level will be affected by the LFO according to the channel's AMS setting. If clear, the operator will not be affected.
 
 **D1R** (Decay Rate 1)
 
-Registers $A0-$BF, Bits 0-4
+Registers \$A0-\$BF, Bits 0-4
 
 Controls the rate at which the level falls from peak down to the sustain level (D1L). 0=none, $1F=fastest.
 
 **DT2** (Detune 2 - coarse)
 
-Registers $C0-$DF, Bits 6-7
+Registers \$C0-\$DF, Bits 6-7
 
 Sets a strong detune amount to the operator's frequency. Yamaha suggests that this is most useful for sound effects. 0=off,
 
 **D2R** (Decay Rate 2)
 
-Registers $C0-$DF, Bits 0-4
+Registers \$C0-\$DF, Bits 0-4
 
 Sets the Decay2 rate, which takes effect once the level has fallen from peak down to the sustain level (D1L). This rate continues
 until the level reaches zero or until the note is released.
@@ -818,13 +818,13 @@ until the level reaches zero or until the note is released.
 
 **D1L**
 
-Registers $E0-$FF, Bits 4-7
+Registers \$E0-\$FF, Bits 4-7
 
 Sets the level at which the ADSR envelope changes decay rates from D1R to D2R. 0=minimum (no D2R), $0F=maximum (immediately at peak, which effectively disables D1R)
 
 **RR**
 
-Registers $E0-$FF, Bitst 0-3
+Registers \$E0-\$FF, Bitst 0-3
 
 Sets the rate at which the level drops to zero when a note is released. 0=none, $0F=fastest
 
@@ -860,9 +860,9 @@ Key state and voice selection are both contained in the value written into the K
 
 **Simple Examples:**
 
-To release the note in channel 4: write $08 to `YM_address` ($9F40) and then write $04 ($00+4) to `YM_data` ($9F41).
+To release the note in channel 4: write $08 to `YM_address` ($9F40) and then write \$04 (\$00+4) to `YM_data` (\$9F41).
 
-To begin a note on channel 7, write $08 into `YM_address` to select the KON register. Then write $7F ($78+7) into `YM_data`
+To begin a note on channel 7, write $08 into `YM_address` to select the KON register. Then write \$7F (\$78+7) into `YM_data`
 
 If the current key state of a channel is not known, you can write key off and then key on immediately (after waiting for the YM busy period to end, of course):
 
@@ -878,9 +878,9 @@ The ADSR parameters will be discussed in more detail later.
 
 **Advanced:**
 
-Each channel (voice) of the YM2151 uses 4 operators which can be gated together or independently. Independent triggering gives lots of advanced possibilities. To trigger and release operators independently, you use different values than $78 or $00. These values are composed by 4 bits which signal the on/off state for each operator.
+Each channel (voice) of the YM2151 uses 4 operators which can be gated together or independently. Independent triggering gives lots of advanced possibilities. To trigger and release operators independently, you use different values than \$78 or \$00. These values are composed by 4 bits which signal the on/off state for each operator.
 
-Suppose a note is playing on channel 2 with all 4 operators active. You can release only the M1 operator by writing $72 into register $08.
+Suppose a note is playing on channel 2 with all 4 operators active. You can release only the M1 operator by writing \$72 into register \$08.
 
 **The KON value format:**
 
@@ -958,7 +958,7 @@ To get started quickly, here is some BASIC code to patch voice 0 with a marimba 
 
 Once a voice has been patched as above, you can now POKE notes into it with very few commands for each note.
 
-Patches consist mostly of ADSR envelope parameters. A complete patch contains values for the $20 range register (LR|FB|CON), for the $38 range register (AMS|PMS), and 4 values for each of the parameter ranges starting at $40. (4 operators per voice means 4 values per parameter). Since this is a huge amount of flexibility, it is recommended to experiment with instrument creation in an application such as a chip tracker or VST, as the creative process of instrument design is very hands-on and subjective.
+Patches consist mostly of ADSR envelope parameters. A complete patch contains values for the \$20 range register (LR|FB|CON), for the \$38 range register (AMS|PMS), and 4 values for each of the parameter ranges starting at \$40. (4 operators per voice means 4 values per parameter). Since this is a huge amount of flexibility, it is recommended to experiment with instrument creation in an application such as a chip tracker or VST, as the creative process of instrument design is very hands-on and subjective.
 
 ## Using the LFO
 
@@ -968,7 +968,7 @@ You can re-trigger the LFO by setting and then clearing the `LR` bit in the test
 
 ### Vibrato
 
-Use Phase Modulation on the desired channels. The `PMS` parameter for each channel allows them to vary their vibrato depths individually. Channels with `PMS` set to zero will have no vibrato. The values given earlier in the `PMS` parameter description represent their maximum amount of affect. These values are modified by the global `PMD.` A `PMD` valie of $7F means 100% effectiveness, $40 means all channels' vibrato depths will be reduced by half, etc.
+Use Phase Modulation on the desired channels. The `PMS` parameter for each channel allows them to vary their vibrato depths individually. Channels with `PMS` set to zero will have no vibrato. The values given earlier in the `PMS` parameter description represent their maximum amount of affect. These values are modified by the global `PMD.` A `PMD` valie of \$7F means 100% effectiveness, \$40 means all channels' vibrato depths will be reduced by half, etc.
 
 The vibrato speed is global, depending solely on the value set to `LFRQ.`
 

--- a/X16 Reference - 11 - Sound Programming.md
+++ b/X16 Reference - 11 - Sound Programming.md
@@ -153,7 +153,7 @@ You must include a delay between writes to the address select register ($9F40) a
 
 The YM becomes `BUSY` for approximately 150 CPU cycles' (at 8Mhz) whenever it receives a data write. *Any writes into YM_data during this `BUSY` period will be ignored!*
 
-In order to avoid this, you can use the `BUSY` flag which is bit 7 of the `YM status` byte. Read the status byte from `YM_data` (0x9F41). If the top bit (7) is set, the YM may not be written into at this time. Note that it is not _required_ that you read `YM_status`, only that writes occur no less than ~150 CPU cycles apart. For instance, BASIC executes slowly enough that you are in no danger of writing into the YM too quickly, so BASIC programs may skip checking `YM_status`.
+In order to avoid this, you can use the `BUSY` flag which is bit 7 of the `YM status` byte. Read the status byte from `YM_data` ($9F41). If the top bit (7) is set, the YM may not be written into at this time. Note that it is not _required_ that you read `YM_status`, only that writes occur no less than ~150 CPU cycles apart. For instance, BASIC executes slowly enough that you are in no danger of writing into the YM too quickly, so BASIC programs may skip checking `YM_status`.
 
 Lastly, the `BUSY` flag sometimes takes a (very) short period before it goes high. This has only been observed when IMMEDIATELY polling the flag after a write into `YM_data.` As long as your code does not do so, this quirk should not be an issue.
 

--- a/X16 Reference - 12 - IO Programming.md
+++ b/X16 Reference - 12 - IO Programming.md
@@ -1,7 +1,7 @@
 
 # Chapter 12: I/O Programming
 
-There are two 65C22 "Versatile Interface Adapter" (VIA) I/O controllers in the system, VIA#1 at address $9F00 and VIA#2 at address $9F10. The IRQ out pin of VIA#1 is connected to the CPU's IRQ line, while the IRQ out pin of VIA#2 can be configured via jumper to connect to either the CPU's IRQ or NMI line on production boards (those beginning with serial PR), or hardwired to the CPU's IRQ line on earlier boards.  
+There are two 65C22 "Versatile Interface Adapter" (VIA) I/O controllers in the system, VIA#1 at address \$9F00 and VIA#2 at address \$9F10. The IRQ out pin of VIA#1 is connected to the CPU's IRQ line, while the IRQ out pin of VIA#2 can be configured via jumper to connect to either the CPU's IRQ or NMI line on production boards (those beginning with serial PR), or hardwired to the CPU's IRQ line on earlier boards.  
 
 The-following tables describe the connections of the I/O pins:
 
@@ -45,31 +45,31 @@ The Commander X16 contains an I2C bus, which is implemented through two pins of 
 The system management controller (SMC) is device $42 on the I2C bus. It controls the activity LED, and can be used to power down the system or inject RESET and NMI signals. It also handles communication with
 the PS/2 keyboard and mouse.
 
-| Register | Value           | Description               |
-|----------|-----------------|---------------------------|
-| $01      | $00           | Power off                 |
-| $01      | $01           | Hard reboot               |
-| $02      | $00           | Inject RESET              |
-| $03      | $00           | Inject NMI                |
-| $05      | $00/$FF     | Activity LED off/on   |
+| Register | Value          | Description               |
+|----------|----------------|---------------------------|
+| $01      | $00            | Power off                 |
+| $01      | $01            | Hard reboot               |
+| $02      | $00            | Inject RESET              |
+| $03      | $00            | Inject NMI                |
+| $05      | \$00/\$FF      | Activity LED off/on       |
 | $07      | -              | Read from keyboard buffer |
-| $08      | $00..$FF     | Echo                      |
+| $08      | \$00..\$FF     | Echo                      |
 | $18      | -              | Read ps2 status           |
-| $19      | $00..$FF     | Send ps2 command          |
-| $1A      | $0000..$FFFF | Send ps2 command (2 bytes) |
-| $20      | $00           | Set mouse device ID, standard mouse |
-| $20      | $03           | Set mouse device ID, Intellimouse with scroll wheel |
-| $20      | $04           | Set mouse device ID, Intellimouse with scroll wheel+extra buttons |
+| $19      | \$00..\$FF     | Send ps2 command          |
+| $1A      | \$0000..\$FFFF | Send ps2 command (2 bytes) |
+| $20      | $00            | Set mouse device ID, standard mouse |
+| $20      | $03            | Set mouse device ID, Intellimouse with scroll wheel |
+| $20      | $04            | Set mouse device ID, Intellimouse with scroll wheel+extra buttons |
 | $21      | -              | Read from mouse buffer    |
 | $22      | -              | Get mouse device ID |
 | $30      | -              | Get SMC firmware version, major |
 | $31      | -              | Get SMC firmware version, minor |
 | $32      | -              | Get SMC firmare version, patch |
-| $8F      | $31           | Start bootloader, if present |  
+| $8F      | $31            | Start bootloader, if present |  
 
 ### Real-Time-Clock
 
-The Commander X16 contains a battery-backed Microchip MCP7940N real-time-clock (RTC) chip as device $6F. It provide a real-time clock/calendar, two alarms and 64 bytes of battery-backed SRAM (non-volatile RAM).
+The Commander X16 contains a battery-backed Microchip MCP7940N real-time-clock (RTC) chip as device $6F. It provides a real-time clock/calendar, two alarms and 64 bytes of battery-backed SRAM (non-volatile RAM).
 
 | Register | Description        |
 |----------|--------------------|
@@ -105,34 +105,34 @@ The Commander X16 contains a battery-backed Microchip MCP7940N real-time-clock (
 | $1D      | Power-up hours     |
 | $1E      | Power-up day       |
 | $1F      | Power-up month     |
-| $20-$5F  | 64 Bytes SRAM      |
+| \$20-\$5F  | 64 Bytes SRAM      |
 
 ####  SRAM (NVRAM)
-| Register | Description        |
-|----------|--------------------|
-| $20-$3F  | User NVRAM         |
-| $40-$5F  | KERNAL NVRAM       |
-| $40      | Active profile     |
-| $41-$4D  | Profile 0 (80x60)  |
-| $4E-$5A  | Profile 1 (40x30)  |
-| $41/$4E  | Screen mode        |
-| $42/$4F  | VERA_DC_VIDEO      |
-| $43/$50  | VERA_DC_HSCALE     |
-| $44/$51  | VERA_DC_VSCALE     |
-| $45/$52  | VERA_DC_BORDER     |
-| $46/$53  | VERA_DC_HSTART     |
-| $47/$54  | VERA_DC_HSTOP      |
-| $48/$55  | VERA_DC_VSTART     |
-| $49/$56  | VERA_DC_VSTOP      |
-| $4A/$57  | Color (bg/fg)      |
-| $4B/$58  | Keymap             |
-| $4C/$59  | Typematic          |
-| $4D/$5A  | Unused             |
-| $5B-$5E  | Expansion (unused) |
-| $5F      | Checksum           |
+| Register  | Description        |
+|-----------|--------------------|
+| \$20-\$3F | User NVRAM         |
+| \$40-\$5F | KERNAL NVRAM       |
+| $40       | Active profile     |
+| \$41-\$4D | Profile 0 (80x60)  |
+| \$4E-\$5A | Profile 1 (40x30)  |
+| \$41/\$4E | Screen mode        |
+| \$42/\$4F | VERA_DC_VIDEO      |
+| \$43/\$50 | VERA_DC_HSCALE     |
+| \$44/\$51 | VERA_DC_VSCALE     |
+| \$45/\$52 | VERA_DC_BORDER     |
+| \$46/\$53 | VERA_DC_HSTART     |
+| \$47/\$54 | VERA_DC_HSTOP      |
+| \$48/\$55 | VERA_DC_VSTART     |
+| \$49/\$56 | VERA_DC_VSTOP      |
+| \$4A/\$57 | Color (bg/fg)      |
+| \$4B/\$58 | Keymap             |
+| \$4C/\$59 | Typematic          |
+| \$4D/\$5A | Unused             |
+| \$5B-\$5E | Expansion (unused) |
+| $5F       | Checksum           |
 
 
-The second half of the RTC's SRAM (NVRAM) is reserved for use by the KERNAL.  $20-$3F is available for use by user programs.
+The second half of the RTC's SRAM (NVRAM) is reserved for use by the KERNAL. \$20-\$3F is available for use by user programs.
 
 For more information, please refer to this device's datasheet.
 

--- a/X16 Reference - 14 - Hardware.md
+++ b/X16 Reference - 14 - Hardware.md
@@ -129,7 +129,7 @@ Expansion cards can use the IO3-IO6 lines as enable lines to provide their IO ad
 devices, expansion boards should allow the user to select their desired I/O bank with jumpers
 or DIP switches. IO7 is given priority to external cartridges that use MMIO and should be
 only used by an expansion card if there are no other MMIO ranges available. Doing so may
-cause a bus conflict with cartridges that make us of MMIO (such as those with expansion
+cause a bus conflict with cartridges that make use of MMIO (such as those with expansion
 hardware). See below for more information on cartridges.
 
 ROMB0-ROMB7 are connected to the ROM bank latch at address `$01`. Values 0-31 (`$00`-`$1F`)

--- a/X16 Reference - Appendix E - Diagnostic Bank.md
+++ b/X16 Reference - Appendix E - Diagnostic Bank.md
@@ -37,10 +37,10 @@ This will make the Commander X16 boot directly into the diagnostic ROM bank and 
 ### Without screen
 When the diagnostic ROM bank starts, it will use the activity LED to indicate the progress.  
 * ON - while zero-page memory is tested (very brief)
-* OFF - for 1st test of base memory ($0100-$9EFF)
-* ON - for 2nd test of base memory ($0100-$9EFF)
-* OFF - for 3rd test of base memory ($0100-$9EFF)
-* ON - for 4th test of base memory ($0100-$9EFF)
+* OFF - for 1st test of base memory (\$0100-\$9EFF)
+* ON - for 2nd test of base memory (\$0100-\$9EFF)
+* OFF - for 3rd test of base memory (\$0100-\$9EFF)
+* ON - for 4th test of base memory (\$0100-\$9EFF)
   
 After the initial test of base memory, the number of available memory banks is tested, VERA is initialized and both the activity LED and the keyboard LEDs are used to indicate the progress.  
 The keyboard LEDs are used as a binary counter:  
@@ -108,16 +108,16 @@ The algorithm is then implemented in the following way:
 2. For each address, check the pattern and write the inverted pattern in ascending order
 3. For each address, check the inverted pattern and write the original pattern in ascending order
 4. For each address, check the original pattern and write the inverted pattern in descending order
-5. For eac address, check the inverted pattern and write the original pattern in descending order
+5. For each address, check the inverted pattern and write the original pattern in descending order
 6. Check all addresses contain the original pattern
 ### Implementation
-When memory test starts, the first thing that happens is that zero-page is tested by itself. If this test passes, the rest of base memory is tested from $0100-$9EFF while ensuring that these tests do not affect zero-page memory.  
+When memory test starts, the first thing that happens is that zero-page is tested by itself. If this test passes, the rest of base memory is tested from \$0100-\$9EFF while ensuring that these tests do not affect zero-page memory.  
   
 When base memory has passed the initial test, zero-page is used for variables and stack pointer is initialized to enable pushing and popping of registers and function calls.  
 VERA is initialized and the number of memory banks is tested.  
   
 All available memory banks are tested together as opposed to checking and clearing a single memory page at a time.  
-When all memory banks have been tested, the base memory $0200-$9EFF is tested again.  
+When all memory banks have been tested, the base memory \$0200-\$9EFF is tested again.  
   
 Memory banks and base memory is tested in continuous loop.  
   

--- a/X16 Reference - Appendix F - 65C816 Processor.md
+++ b/X16 Reference - Appendix F - 65C816 Processor.md
@@ -62,7 +62,7 @@ to the $100-1FF range) in Emulation mode.
 
 .DB and .K are the bank registers, allowing programs and data to occupy separate
 64K banks on computers with more than 64K of RAM. (The X16 does not use the bank
-registers, instead using addresses $00 and $01 for banking.)
+registers, instead using addresses \$00 and \$01 for banking.)
 
 ## Status Flags
 
@@ -178,8 +178,8 @@ all _emulate_ 65C02 behavior when _set_.
 The 65C816 now has 24 distinct address modes, although most are variations on a
 theme. Make note of the new syntax for Stack relative instructions (,S), the use
 of brackets for [24 bit indirect] addressing, and the fact that Zero Page has
-been renamed to Direct Page. This means that $0001 and $01 are now two different
-addresses (although they would be the same if .DP is set to $00.
+been renamed to Direct Page. This means that \$0001 and \$01 are now two different
+addresses (although they would be the same if .DP is set to \$00.
 
 | Mode                            | Syntax    | Description |
 | ------------------------------- | --------- | ------------------------------------------------------------------ |
@@ -206,7 +206,7 @@ addresses (although they would be the same if .DP is set to $00.
 | Implied                         |           | Target is part of the opcode name.                                 |
 | Relative Address (8 bit signed) | $1234     | Branches can only jump by -128 to 127 bytes.                       |
 | 16 bit relative address         | $1234     | BRL can jump by 32K bytes.                                         |
-| Block Move                      | #$12,#$34 | Operands are the bank numbers for block move/copy.                 |
+| Block Move                      | #\$12,#\$34 | Operands are the bank numbers for block move/copy.                 |
 
 ## Vectors
 
@@ -278,12 +278,12 @@ inverted: 0 indicates a borrow took place, and 1 means it did not.
 | SBC #$01  | $10  | $09    | Carry is set, indicating no borrow. |
 | SBC #$01  | $00  | $99    | Carry is clear, indicating a borrow.|
 
-In the second example ($00 - $01), the final result was $99 with a borrow. 
+In the second example (\$00 - \$01), the final result was \$99 with a borrow. 
 
 Note that the **n** flag tracks the high bit, but two's complement doesn't work
 as expected in Decimal mode. Instead, we have to use _Ten's complement_. 
 
-Simply put, $00 - $01 gives you $99. So when working in signed BCD, any value
+Simply put, \$00 - \$01 gives you \$99. So when working in signed BCD, any value
 where the high digit is 5-9 is actually a negative value. To convert negative
 values to positive values for printing, you would subtract from 99 and add 1.
 
@@ -764,7 +764,7 @@ instruction _following_ The BRL.
 
 Of course, due to wrapping of the 64K bank, this means that the entire 64K
 region is accessible. Values below 0 will simply wrap around and start from
-$FFFF, and values above $FFFF will wrap around to 0.
+\$FFFF, and values above \$FFFF will wrap around to 0.
 
 Since this is a _relative_ branch, that means code assembled with BRL, instead of
 JMP, can be moved around in memory without the need for re-assembly.
@@ -883,8 +883,8 @@ SYNTAX           MODE       HEX LEN CYCLES      FLAGS
 CLV              imp        B8  1   2           .v...... .
 ```
 
-Overflow is _set_ when the result of an addition operation goes up through $80
-or subtraction goes down through $80.
+Overflow is _set_ when the result of an addition operation goes up through \$80
+or subtraction goes down through \$80.
 
 CLV clears the overflow flag. There is no "SEV" instruction, but overflow can be
 set with SEP #$40.
@@ -1630,7 +1630,7 @@ by 1 byte.
 A 16-bit push writes the high byte first, decrements the PC, then writes the low
 byte, and decrements the PC again.
 
-In Emulation mode, the Stack Pointer will always be an address in the $100-$1FF
+In Emulation mode, the Stack Pointer will always be an address in the \$100-\$1FF
 range, so there is only room for 256 bytes on the stack. In native mode, the
 stack can be anywhere in the first 64KB of RAM.
 
@@ -2071,16 +2071,16 @@ When Decimal is set, the CPU will store numbers in Binary Coded Decimal format.
 Clearing this flag restores the CPU to binary operation. See
 [Decimal Mode](#decimal-mode) for more information.
 
-In binary mode, adding 1 to $09 will set the Accumulator to $0A. In BCD mode,
-adding 1 to $09 will set the Accumulator to $10.
+In binary mode, adding 1 to \$09 will set the Accumulator to \$0A. In BCD mode,
+adding 1 to \$09 will set the Accumulator to \$10.
 
 Using BCD allows for easier conversion of binary numbers to decimal. BCD also
 allows for storing decimal numbers without loss of precision due to power-of-2
 rounding.
 
 An add or subtract (ADC or SBC) is required to actually trigger BCD conversion.
-So if you have a number like $1A on the accumulator and you SED, you can convert
-.A to $20 with the instruction `ADC #$00`.
+So if you have a number like \$1A on the accumulator and you SED, you can convert
+.A to \$20 with the instruction `ADC #$00`.
 
 
 [[Opcodes](#instructions-by-opcode)] [[By Name](#instructions-by-name)] [[By Category](#instructions-by-category)]


### PR DESCRIPTION
In IntelliJ IDEA, the preview can get quite difficult to read due to non-maths things getting interpreted as math notation. This isn't an issue in Obsidian, VS Code or GitHub's own preview, despite all of those supporting math notation (as evidenced in the [Math Library](https://github.com/X16Community/x16-docs/blob/master/X16%20Reference%20-%2006%20-%20Math%20Library.md#how-to-use-the-routines) chapter).

|![IDEA screenshot](https://github.com/user-attachments/assets/ae18e0ec-8e1f-4e09-8c73-9ead477a7feb)|
|---|
|![IDEA screenshot](https://github.com/user-attachments/assets/3b01566d-3145-44e5-987a-28c74494132c)|

To fix this, in paragraphs that contain two or more dollar signs (excluding in `monospace`) I've escaped them. Paragraphs which contain only a single dollar sign, I've left alone. This was a manual job, so some stuff may have been missed.

Let me make it clear I'm not overly keen on this solution and I understand if it's rejected. However, I'd still like to have the discussion, even if just to have something to point to if this comes up again.

Funnily enough, whatever generates the PDF bundled with the emulator doesn't support (or doesn't have enabled) math notation at all!

![PDF screenshot](https://github.com/user-attachments/assets/9844d273-89be-4513-b87a-4f0dffb2ce66)