### PR TITLE
Fixing conflicting info in Appendix B - VERA recovery

### DIFF
--- a/X16 Reference - Appendix B - VERA Recovery.md
+++ b/X16 Reference - Appendix B - VERA Recovery.md
@@ -70,7 +70,8 @@ Open the Xgpro software and configure the following settings:
 - Click on "ID Check" to verify the connection
     - The response value should be EF 40 15
     - If it is not, double-check the wiring before proceeding
-
+      
+<img width="600" alt="xgpro-window" src="https://github.com/user-attachments/assets/cdaebea2-df90-4abe-8805-a2e42f936f87" />
 
 ### Update/Flash Procedure
 


### PR DESCRIPTION
There is conflicting information in the current doc.

The VERA is powered by the X16 and ICSP_VCC in the Xgpro interface should be unchecked. This is mentioned in the text, but the screenshot of the interface has the option checked.

I'm replacing the screenshot so there is no conflicting information.